### PR TITLE
sqlcon: add support for tracing database driver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect
-	github.com/opentracing/opentracing-go v1.0.2 // indirect
+	github.com/opentracing/opentracing-go v1.0.2
 	github.com/ory/dockertest v3.3.2+incompatible
 	github.com/ory/fosite v0.25.0
 	github.com/ory/go-convenience v0.1.0
@@ -27,6 +27,7 @@ require (
 	github.com/pkg/errors v0.8.0
 	github.com/pkg/profile v1.2.1
 	github.com/rs/cors v1.5.0
+	github.com/satori/go.uuid v1.2.0
 	github.com/segmentio/analytics-go v3.0.1+incompatible
 	github.com/segmentio/backo-go v0.0.0-20160424052352-204274ad699c // indirect
 	github.com/sirupsen/logrus v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,11 @@ require (
 	github.com/jmoiron/sqlx v0.0.0-20180614180643-0dae4fefe7c0
 	github.com/julienschmidt/httprouter v0.0.0-20180715161854-348b672cd90d
 	github.com/lib/pq v1.0.0
+	github.com/luna-duclos/instrumentedsql v0.0.0-20181016211422-eae529699c8a
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect
+	github.com/opentracing/opentracing-go v1.0.2 // indirect
 	github.com/ory/dockertest v3.3.2+incompatible
 	github.com/ory/fosite v0.25.0
 	github.com/ory/go-convenience v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/cors v1.5.0 h1:dgSHE6+ia18arGOTIYQKKGWLvEbGvmbNE6NfxhoNHUY=
 github.com/rs/cors v1.5.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
+github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
+github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/segmentio/analytics-go v3.0.1+incompatible h1:W7T3ieNQjPFMb+SE8SAVYo6mPkKK/Y37wYdiNf5lCVg=
 github.com/segmentio/analytics-go v3.0.1+incompatible/go.mod h1:C7CYBtQWk4vRk2RyLu0qOcbHJ18E3F1HV2C/8JvKN48=
 github.com/segmentio/backo-go v0.0.0-20160424052352-204274ad699c h1:rsRTAcCR5CeNLkvgBVSjQoDGRRt6kggsE6XYBqCv2KQ=

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f26
 github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f2633dfe/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/luna-duclos/instrumentedsql v0.0.0-20181016211422-eae529699c8a h1:c+XmkcFn/TPzhQb54T5SIXaF3PlGbnjdcArRfTK9L04=
+github.com/luna-duclos/instrumentedsql v0.0.0-20181016211422-eae529699c8a/go.mod h1:PWUIzhtavmOR965zfawVsHXbEuU1G29BPZ/CB3C7jXk=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mitchellh/mapstructure v1.0.0 h1:vVpGvMXJPqSDh2VYHF7gsfQj8Ncx+Xw5Y1KHeTRY+7I=
@@ -60,6 +62,8 @@ github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVo
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.1.1 h1:GlxAyO6x8rfZYN9Tt0Kti5a/cP41iuiO2yYT0IJGY8Y=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
+github.com/opentracing/opentracing-go v1.0.2 h1:3jA2P6O1F9UOrWVpwrIo17pu01KWvNWg4X946/Y5Zwg=
+github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/ory/dockertest v3.3.2+incompatible h1:uO+NcwH6GuFof/Uz8yzjNi1g0sGT5SLAJbdBvD8bUYc=
 github.com/ory/dockertest v3.3.2+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
 github.com/ory/fosite v0.25.0 h1:GELSEQc6OIDsfvtx1nC0snzPpFF14W/f6MeMXPEiZ9I=

--- a/sqlcon/connector.go
+++ b/sqlcon/connector.go
@@ -23,7 +23,6 @@ package sqlcon
 import (
 	"database/sql"
 	"fmt"
-	"github.com/satori/go.uuid"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/lib/pq"
@@ -212,8 +211,8 @@ func (c *SQLConnection) registerDriver() (string, error) {
 	driverName := c.URL.Scheme
 	if c.UseTracedDriver {
 		driverName = "instrumented-sql-driver"
-		if c.useRandomDriverName {
-			driverName = uuid.NewV4().String()
+		if len(c.options.forcedDriverName) > 0 {
+			driverName = c.options.forcedDriverName
 		}
 
 		tracingOpts := []instrumentedsql.Opt{instrumentedsql.WithTracer(opentracing.NewTracer(c.AllowRoot))}

--- a/sqlcon/connector.go
+++ b/sqlcon/connector.go
@@ -23,6 +23,7 @@ package sqlcon
 import (
 	"database/sql"
 	"fmt"
+	"github.com/satori/go.uuid"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/lib/pq"
@@ -211,6 +212,10 @@ func (c *SQLConnection) registerDriver() (string, error) {
 	driverName := c.URL.Scheme
 	if c.UseTracedDriver {
 		driverName = "instrumented-sql-driver"
+		if c.useRandomDriverName {
+			driverName = uuid.NewV4().String()
+		}
+
 		tracingOpts := []instrumentedsql.Opt{instrumentedsql.WithTracer(opentracing.NewTracer(c.AllowRoot))}
 		if c.OmitArgs {
 			tracingOpts = append(tracingOpts, instrumentedsql.WithOmitArgs())

--- a/sqlcon/options.go
+++ b/sqlcon/options.go
@@ -1,10 +1,12 @@
 package sqlcon
 
+import "github.com/satori/go.uuid"
+
 type options struct {
-	UseTracedDriver     bool
-	OmitArgs            bool
-	AllowRoot           bool
-	useRandomDriverName bool
+	UseTracedDriver  bool
+	OmitArgs         bool
+	AllowRoot        bool
+	forcedDriverName string
 }
 
 type Opt func(*options)
@@ -35,6 +37,6 @@ func WithAllowRoot() Opt {
 // Reason for this option is because you can't register a driver with the same name more than once
 func withRandomDriverName() Opt {
 	return func(o *options) {
-		o.useRandomDriverName = true
+		o.forcedDriverName = uuid.NewV4().String()
 	}
 }

--- a/sqlcon/options.go
+++ b/sqlcon/options.go
@@ -1,0 +1,22 @@
+package sqlcon
+
+type options struct {
+	UseTracedDriver bool
+	OmitArgs        bool
+}
+
+type Opt func(*options)
+
+// WithDistributedTracing will make it so that a wrapped driver is used that supports the opentracing API
+func WithDistributedTracing() Opt {
+	return func(o *options) {
+		o.UseTracedDriver = true
+	}
+}
+
+// WithOmitArgsFromTraceSpans will make it so that query arguments are omitted from tracing spans
+func WithOmitArgsFromTraceSpans() Opt {
+	return func(o *options) {
+		o.OmitArgs = true
+	}
+}

--- a/sqlcon/options.go
+++ b/sqlcon/options.go
@@ -1,9 +1,10 @@
 package sqlcon
 
 type options struct {
-	UseTracedDriver bool
-	OmitArgs        bool
-	AllowRoot       bool
+	UseTracedDriver     bool
+	OmitArgs            bool
+	AllowRoot           bool
+	useRandomDriverName bool
 }
 
 type Opt func(*options)
@@ -27,5 +28,13 @@ func WithOmitArgsFromTraceSpans() Opt {
 func WithAllowRoot() Opt {
 	return func(o *options) {
 		o.AllowRoot = true
+	}
+}
+
+// This option is specifically for tests, hence why it is unexported...
+// Reason for this option is because you can't register a driver with the same name more than once
+func withRandomDriverName() Opt {
+	return func(o *options) {
+		o.useRandomDriverName = true
 	}
 }

--- a/sqlcon/options.go
+++ b/sqlcon/options.go
@@ -3,6 +3,7 @@ package sqlcon
 type options struct {
 	UseTracedDriver bool
 	OmitArgs        bool
+	AllowRoot       bool
 }
 
 type Opt func(*options)
@@ -18,5 +19,13 @@ func WithDistributedTracing() Opt {
 func WithOmitArgsFromTraceSpans() Opt {
 	return func(o *options) {
 		o.OmitArgs = true
+	}
+}
+
+// WithAllowRoot will make it so that root spans will be created if a trace could not be found using
+// opentracing's SpanFromContext method
+func WithAllowRoot() Opt {
+	return func(o *options) {
+		o.AllowRoot = true
 	}
 }


### PR DESCRIPTION
## What does this PR do?
This PR adds support for tracing db queries by wrapping the driver with one instrumented w/ the opentracing API. This new ability has been introduced in a backwards compatible manner by following the options pattern: https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis

Existing consumers of the `sqlcon` package need not worry if they have no need for distributed tracing - **their code will work as is**.

Consumers of `sqlcon` interested in tracing their db calls (_e.g. Ory Hydra_) can now do something like:

```
	options := []sqlcon.Opt{sqlcon.WithDistributedTracing(), sqlcon.WithOmitArgsFromTraceSpans()}
	connection, err := sqlcon.NewSQLConnection(url, l, options...)
	if err != nil {
		return err
	}
	s.l = l
	s.db = connection.GetDatabase()
```

## Other notes:

• New dependency has been added as per discussed in [proposal](https://docs.google.com/document/d/1c380H_gCpFDpN_LU-GImPjW-9I30cOlBMYYBtGZa0Xc/edit?usp=sharing) - https://github.com/luna-duclos/instrumentedsql

_Review: @aeneasr_

Signed-off-by: Amir Aslaminejad <aslaminejad@gmail.com>