### PR TITLE
sqlcon: expose option for using random driver names when configuring tracing

### DIFF
--- a/sqlcon/connector_test.go
+++ b/sqlcon/connector_test.go
@@ -82,27 +82,27 @@ func TestDistributedTracing(t *testing.T) {
 			description: "mysql: when tracing has been configured - spans should be created",
 			sqlConnection: mustSQL(t, mysqlUrl.String(),
 				WithDistributedTracing(),
-				withRandomDriverName(), // this test option is set to ensure a unique driver name is registered
+				WithRandomDriverName(), // this test option is set to ensure a unique driver name is registered
 				WithAllowRoot()),
 		},
 		{
 			description: "postgres: when tracing has been configured - spans should be created",
 			sqlConnection: mustSQL(t, postgresUrl.String(),
 				WithDistributedTracing(),
-				withRandomDriverName(), // this test option is set to ensure a unique driver name is registered
+				WithRandomDriverName(), // this test option is set to ensure a unique driver name is registered
 				WithAllowRoot()),
 		},
 		{
 			description: "mysql: no spans should be created if parent span is missing from context when `WithAllowRoot` has NOT been set",
 			sqlConnection: mustSQL(t, mysqlUrl.String(),
 				WithDistributedTracing(), // Notice that the WithAllowRoot() option has NOT been set
-				withRandomDriverName()),  // this test option is set to ensure a unique driver name is registered
+				WithRandomDriverName()),  // this test option is set to ensure a unique driver name is registered
 		},
 		{
 			description: "postgres: no spans should be created if parent span is missing from context when `WithAllowRoot` has NOT been set",
 			sqlConnection: mustSQL(t, postgresUrl.String(),
 				WithDistributedTracing(), // Notice that the WithAllowRoot() option has NOT been set
-				withRandomDriverName()),  // this test option is set to ensure a unique driver name is registered
+				WithRandomDriverName()),  // this test option is set to ensure a unique driver name is registered
 		},
 		{
 			description:   "mysql: when tracing has NOT been configured - NO spans should be created",

--- a/sqlcon/options.go
+++ b/sqlcon/options.go
@@ -1,7 +1,5 @@
 package sqlcon
 
-import "github.com/satori/go.uuid"
-
 type options struct {
 	UseTracedDriver  bool
 	OmitArgs         bool
@@ -33,9 +31,8 @@ func WithAllowRoot() Opt {
 	}
 }
 
-// This option is specifically for tests, hence why it is unexported...
-// Reason for this option is because you can't register a driver with the same name more than once
-func withRandomDriverName() Opt {
+// This option is specifically for writing tests as you can't register a driver with the same name more than once
+func WithRandomDriverName() Opt {
 	return func(o *options) {
 		o.forcedDriverName = uuid.NewV4().String()
 	}


### PR DESCRIPTION
This will be useful for writing integration tests in Hydra as you cannot register a driver with the same name more than once.

👀 @aeneasr 