### PR TITLE
Don't watch for shutdown signal on profiling

### DIFF
--- a/profilex/profiling.go
+++ b/profilex/profiling.go
@@ -17,21 +17,21 @@ func Profile() interface {
 } {
 	switch os.Getenv("PROFILING") {
 	case "cpu":
-		return profile.Start(profile.CPUProfile)
+		return profile.Start(profile.CPUProfile, profile.NoShutdownHook)
 	case "mem":
-		return profile.Start(profile.MemProfile)
+		return profile.Start(profile.MemProfile, profile.NoShutdownHook)
 	case "mutex":
-		return profile.Start(profile.MutexProfile)
+		return profile.Start(profile.MutexProfile, profile.NoShutdownHook)
 	case "block":
-		return profile.Start(profile.BlockProfile)
+		return profile.Start(profile.BlockProfile, profile.NoShutdownHook)
 	}
 	return new(noop)
 }
 
 // HelpMessage returns a string explaining how profiling works.
 func HelpMessage() string {
-	return `- PROFILING: Set "PROFILING=cpu" to enable cpu profiling and "PROFILING=memory" to enable memory profiling.
-	It is not possible to do both at the same time. DProfiling is disabled per default.
+	return `- PROFILING: Set "PROFILING=cpu" to enable cpu profiling and "PROFILING=mem" to enable memory profiling.
+	It is not possible to do both at the same time. Profiling is disabled per default.
 
 	Example: PROFILING=cpu`
 }


### PR DESCRIPTION
Signed-off-by: Kevin Minehart <kmineh0151@gmail.com>

## Related issue

https://github.com/ory/hydra/issues/1061

## Proposed changes

`profilex` functions were watching for shutdown signals, causing the file writers to never `Close`.

This change disables watching for shutdown signals in the profile package.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)

## Further comments

I didn't see a very good place to write tests for this type of change. If you have any suggestions, then please let me know. :)