### PR TITLE
add pagination functions for use in ory/hydra

### DIFF
--- a/pagination/header.go
+++ b/pagination/header.go
@@ -20,13 +20,18 @@ func header(u *url.URL, rel string, limit, offset int) string {
 // If total is not set, then no "last" page will be calculated.
 // If no limit is provided, then this function will return an empty map.
 func Header(u *url.URL, total int, limit, offset int) http.Header {
-	if limit == 0 {
-		return http.Header{}
+	if limit <= 0 {
+		limit = 1
 	}
 
-	// lastOffset will either equal the offset required to contain the remainer,
+	// lastOffset will either equal the offset required to contain the remainder,
 	// or the limit.
-	lastOffset := total + (limit - total%limit) - limit
+	var lastOffset int
+	if total%limit == 0 {
+		lastOffset = total - limit
+	} else {
+		lastOffset = ((total / limit) * limit)
+	}
 
 	// Check for last page
 	if offset >= lastOffset {

--- a/pagination/header.go
+++ b/pagination/header.go
@@ -1,0 +1,49 @@
+package pagination
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+func header(u *url.URL, rel string, limit, offset int) string {
+	q := u.Query()
+	q.Set("limit", strconv.Itoa(limit))
+	q.Set("offset", strconv.Itoa(offset))
+	u.RawQuery = q.Encode()
+	return fmt.Sprintf("<%s>; rel=\"%s\"", u.String(), rel)
+}
+
+func Header(u *url.URL, count int, limit, offset int) http.Header {
+	lastOffset := count + (limit - count%limit) - limit
+
+	// Check for first page
+	if offset < limit {
+		return http.Header{
+			"Link": []string{
+				header(u, "next", limit, limit),
+				header(u, "last", limit, lastOffset),
+			},
+		}
+	}
+
+	// Check for last page
+	if offset >= lastOffset {
+		return http.Header{
+			"Link": []string{
+				header(u, "first", limit, 0),
+				header(u, "prev", limit, lastOffset-limit),
+			},
+		}
+	}
+
+	return http.Header{
+		"Link": []string{
+			header(u, "prev", limit, ((offset/limit)-1)*limit),
+			header(u, "next", limit, ((offset/limit)+1)*limit),
+			header(u, "first", limit, 0),
+			header(u, "last", limit, lastOffset),
+		},
+	}
+}

--- a/pagination/header.go
+++ b/pagination/header.go
@@ -18,7 +18,7 @@ func header(u *url.URL, rel string, limit, offset int) string {
 // Header returns an http header map, with a single key, "Link". The "Link" header is used in pagination where backwards compatibility is required.
 // The Link header will contain links any combination of the first, last, next, or previous (prev) pages in a paginated list (given a limit and an offset, and optionally a total).
 // If total is not set, then no "last" page will be calculated.
-// If no limit is provided, then this function will return an empty map.
+// If no limit is provided, then it will default to 1.
 func Header(u *url.URL, total int, limit, offset int) http.Header {
 	if limit <= 0 {
 		limit = 1

--- a/pagination/header_test.go
+++ b/pagination/header_test.go
@@ -1,0 +1,61 @@
+package pagination
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestHeaders(t *testing.T) {
+	u, err := url.Parse("http://example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("Create previous and first but not next or last if at the end", func(t *testing.T) {
+		h := Header(u, 120, 50, 100)
+
+		expect := http.Header{
+			"Link": []string{
+				"<http://example.com?limit=50&offset=0>; rel=\"first\"",
+				"<http://example.com?limit=50&offset=50>; rel=\"prev\"",
+			},
+		}
+
+		if expect.Get("Link") != h.Get("Link") {
+			t.Fatalf("Unexpected response from Header. Expected %s, got %s", expect.Get("Link"), h.Get("Link"))
+		}
+	})
+
+	t.Run("Create next and last, but not previous or first if at the beginning", func(t *testing.T) {
+		h := Header(u, 120, 50, 0)
+
+		expect := http.Header{
+			"Link": []string{
+				"<http://example.com?limit=50&offset=50>; rel=\"next\"",
+				"<http://example.com?limit=50&offset=100>; rel=\"last\"",
+			},
+		}
+
+		if expect.Get("Link") != h.Get("Link") {
+			t.Fatalf("Unexpected response from Header. Expected %s, got %s", expect.Get("Link"), h.Get("Link"))
+		}
+	})
+
+	t.Run("Create previous, next, first, and last if in the middle", func(t *testing.T) {
+		h := Header(u, 300, 50, 150)
+
+		expect := http.Header{
+			"Link": []string{
+				"<http://example.com?limit=50&offset=100>; rel=\"prev\"",
+				"<http://example.com?limit=50&offset=200>; rel=\"next\"",
+				"<http://example.com?limit=50&offset=0>; rel=\"first\"",
+				"<http://example.com?limit=50&offset=250>; rel=\"last\"",
+			},
+		}
+
+		if expect.Get("Link") != h.Get("Link") {
+			t.Fatalf("Unexpected response from Header. Expected %s, got %s", expect.Get("Link"), h.Get("Link"))
+		}
+	})
+}

--- a/pagination/header_test.go
+++ b/pagination/header_test.go
@@ -3,10 +3,11 @@ package pagination
 import (
 	"net/http"
 	"net/url"
+	"reflect"
 	"testing"
 )
 
-func TestHeaders(t *testing.T) {
+func TestHeader(t *testing.T) {
 	u, err := url.Parse("http://example.com")
 	if err != nil {
 		t.Fatal(err)
@@ -22,8 +23,8 @@ func TestHeaders(t *testing.T) {
 			},
 		}
 
-		if expect.Get("Link") != h.Get("Link") {
-			t.Fatalf("Unexpected response from Header. Expected %s, got %s", expect.Get("Link"), h.Get("Link"))
+		if reflect.DeepEqual(expect, h) != true {
+			t.Fatalf("Unexpected response from Header. Expected %s, got %s", expect, h)
 		}
 	})
 
@@ -37,8 +38,8 @@ func TestHeaders(t *testing.T) {
 			},
 		}
 
-		if expect.Get("Link") != h.Get("Link") {
-			t.Fatalf("Unexpected response from Header. Expected %s, got %s", expect.Get("Link"), h.Get("Link"))
+		if reflect.DeepEqual(expect, h) != true {
+			t.Fatalf("Unexpected response from Header. Expected %s, got %s", expect, h)
 		}
 	})
 
@@ -52,8 +53,8 @@ func TestHeaders(t *testing.T) {
 			},
 		}
 
-		if expect.Get("Link") != h.Get("Link") {
-			t.Fatalf("Unexpected response from Header. Expected %s, got %s", expect.Get("Link"), h.Get("Link"))
+		if reflect.DeepEqual(expect, h) != true {
+			t.Fatalf("Unexpected response from Header. Expected %s, got %s", expect, h)
 		}
 	})
 
@@ -62,15 +63,40 @@ func TestHeaders(t *testing.T) {
 
 		expect := http.Header{
 			"Link": []string{
-				"<http://example.com?limit=50&offset=100>; rel=\"prev\"",
-				"<http://example.com?limit=50&offset=200>; rel=\"next\"",
 				"<http://example.com?limit=50&offset=0>; rel=\"first\"",
+				"<http://example.com?limit=50&offset=200>; rel=\"next\"",
+				"<http://example.com?limit=50&offset=100>; rel=\"prev\"",
 				"<http://example.com?limit=50&offset=250>; rel=\"last\"",
 			},
 		}
 
 		if expect.Get("Link") != h.Get("Link") {
 			t.Fatalf("Unexpected response from Header. Expected %s, got %s", expect.Get("Link"), h.Get("Link"))
+		}
+	})
+	t.Run("Header should return an empty http.Header if no limit was provided", func(t *testing.T) {
+		h := Header(u, 20, 0, 10)
+
+		expect := http.Header{}
+
+		if reflect.DeepEqual(expect, h) != true {
+			t.Fatalf("Unexpected response from Header. Expected %s, got %s", expect.Get("Link"), h.Get("Link"))
+		}
+	})
+
+	t.Run("Create previous, next, first, but not last if in the middle and no total was provided", func(t *testing.T) {
+		h := Header(u, 0, 50, 150)
+
+		expect := http.Header{
+			"Link": []string{
+				"<http://example.com?limit=50&offset=0>; rel=\"first\"",
+				"<http://example.com?limit=50&offset=200>; rel=\"next\"",
+				"<http://example.com?limit=50&offset=100>; rel=\"prev\"",
+			},
+		}
+
+		if reflect.DeepEqual(expect, h) != true {
+			t.Fatalf("Unexpected response from Header. Expected %s, got %s", expect, h)
 		}
 	})
 }

--- a/pagination/header_test.go
+++ b/pagination/header_test.go
@@ -24,7 +24,7 @@ func TestHeader(t *testing.T) {
 		}
 
 		if reflect.DeepEqual(expect, h) != true {
-			t.Fatalf("Unexpected response from Header. Expected %s, got %s", expect, h)
+			t.Fatalf("Unexpected response from Header. Expected %+v, got %+v", expect, h)
 		}
 	})
 
@@ -39,7 +39,7 @@ func TestHeader(t *testing.T) {
 		}
 
 		if reflect.DeepEqual(expect, h) != true {
-			t.Fatalf("Unexpected response from Header. Expected %s, got %s", expect, h)
+			t.Fatalf("Unexpected response from Header. Expected %+v, got %+v", expect, h)
 		}
 	})
 
@@ -54,7 +54,7 @@ func TestHeader(t *testing.T) {
 		}
 
 		if reflect.DeepEqual(expect, h) != true {
-			t.Fatalf("Unexpected response from Header. Expected %s, got %s", expect, h)
+			t.Fatalf("Unexpected response from Header. Expected %+v, got %+v", expect, h)
 		}
 	})
 
@@ -71,16 +71,24 @@ func TestHeader(t *testing.T) {
 		}
 
 		if expect.Get("Link") != h.Get("Link") {
-			t.Fatalf("Unexpected response from Header. Expected %s, got %s", expect.Get("Link"), h.Get("Link"))
+			t.Fatalf("Unexpected response from Header. Expected %+v, got %+v", expect.Get("Link"), h.Get("Link"))
 		}
 	})
-	t.Run("Header should return an empty http.Header if no limit was provided", func(t *testing.T) {
-		h := Header(u, 20, 0, 10)
 
-		expect := http.Header{}
+	t.Run("Header should default limit to 1 no limit was provided", func(t *testing.T) {
+		h := Header(u, 100, 0, 20)
+
+		expect := http.Header{
+			"Link": []string{
+				"<http://example.com?limit=1&offset=0>; rel=\"first\"",
+				"<http://example.com?limit=1&offset=21>; rel=\"next\"",
+				"<http://example.com?limit=1&offset=19>; rel=\"prev\"",
+				"<http://example.com?limit=1&offset=99>; rel=\"last\"",
+			},
+		}
 
 		if reflect.DeepEqual(expect, h) != true {
-			t.Fatalf("Unexpected response from Header. Expected %s, got %s", expect.Get("Link"), h.Get("Link"))
+			t.Fatalf("Unexpected response from Header. Expected %+v, got %+v", expect, h)
 		}
 	})
 
@@ -96,7 +104,7 @@ func TestHeader(t *testing.T) {
 		}
 
 		if reflect.DeepEqual(expect, h) != true {
-			t.Fatalf("Unexpected response from Header. Expected %s, got %s", expect, h)
+			t.Fatalf("Unexpected response from Header. Expected %+v, got %+v", expect, h)
 		}
 	})
 }

--- a/pagination/header_test.go
+++ b/pagination/header_test.go
@@ -42,6 +42,21 @@ func TestHeaders(t *testing.T) {
 		}
 	})
 
+	t.Run("Create next and last, but not previous or first if on the first page", func(t *testing.T) {
+		h := Header(u, 120, 50, 10)
+
+		expect := http.Header{
+			"Link": []string{
+				"<http://example.com?limit=50&offset=50>; rel=\"next\"",
+				"<http://example.com?limit=50&offset=100>; rel=\"last\"",
+			},
+		}
+
+		if expect.Get("Link") != h.Get("Link") {
+			t.Fatalf("Unexpected response from Header. Expected %s, got %s", expect.Get("Link"), h.Get("Link"))
+		}
+	})
+
 	t.Run("Create previous, next, first, and last if in the middle", func(t *testing.T) {
 		h := Header(u, 300, 50, 150)
 


### PR DESCRIPTION
Signed-off-by: Kevin Minehart <kmineh0151@gmail.com>

## Related issue

https://github.com/ory/hydra/issues/1047

## Proposed changes

Add a function to create pagination a "Link" header given an offset and a limit.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)

## Further comments

This is a necessary addition in order to complete the issue in Hydra. I figured this was a good place to add the header functionality, in case any other Ory products might use this same type of pagination.

If it should stay in Hydra that would be acceptable as well. Up to you!

I would verify that the logic in place in the tests matches with what you had in mind, @aeneasr