### PR TITLE
Return strings instead of http.Header

### DIFF
--- a/pagination/header.go
+++ b/pagination/header.go
@@ -2,9 +2,9 @@ package pagination
 
 import (
 	"fmt"
-	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 func header(u *url.URL, rel string, limit, offset int) string {
@@ -15,11 +15,11 @@ func header(u *url.URL, rel string, limit, offset int) string {
 	return fmt.Sprintf("<%s>; rel=\"%s\"", u.String(), rel)
 }
 
-// Header returns an http header map, with a single key, "Link". The "Link" header is used in pagination where backwards compatibility is required.
-// The Link header will contain links any combination of the first, last, next, or previous (prev) pages in a paginated list (given a limit and an offset, and optionally a total).
+// Header returns string to be used in an http header map for pagination where backwards compatibility is required.
+// The value returned will contain links any combination of the first, last, next, or previous (prev) pages in a paginated list (given a limit and an offset, and optionally a total).
 // If total is not set, then no "last" page will be calculated.
 // If no limit is provided, then it will default to 1.
-func Header(u *url.URL, total int, limit, offset int) http.Header {
+func Header(u *url.URL, total int, limit, offset int) string {
 	if limit <= 0 {
 		limit = 1
 	}
@@ -36,38 +36,30 @@ func Header(u *url.URL, total int, limit, offset int) http.Header {
 	// Check for last page
 	if offset >= lastOffset {
 		if total == 0 {
-			return http.Header{
-				"Link": []string{
-					header(u, "first", limit, 0),
-					header(u, "next", limit, ((offset/limit)+1)*limit),
-					header(u, "prev", limit, ((offset/limit)-1)*limit),
-				},
-			}
-		}
-		return http.Header{
-			"Link": []string{
+			return strings.Join([]string{
 				header(u, "first", limit, 0),
-				header(u, "prev", limit, lastOffset-limit),
-			},
+				header(u, "next", limit, ((offset/limit)+1)*limit),
+				header(u, "prev", limit, ((offset/limit)-1)*limit),
+			}, ",")
 		}
+		return strings.Join([]string{
+			header(u, "first", limit, 0),
+			header(u, "prev", limit, lastOffset-limit),
+		}, ",")
 	}
 
 	if offset < limit {
-		return http.Header{
-			"Link": []string{
-				header(u, "next", limit, limit),
-				header(u, "last", limit, lastOffset),
-			},
-		}
+		return strings.Join([]string{
+			header(u, "next", limit, limit),
+			header(u, "last", limit, lastOffset),
+		}, ",")
 	}
 
-	return http.Header{
-		"Link": []string{
-			header(u, "first", limit, 0),
-			header(u, "next", limit, ((offset/limit)+1)*limit),
-			header(u, "prev", limit, ((offset/limit)-1)*limit),
-			header(u, "last", limit, lastOffset),
-		},
-	}
+	return strings.Join([]string{
+		header(u, "first", limit, 0),
+		header(u, "next", limit, ((offset/limit)+1)*limit),
+		header(u, "prev", limit, ((offset/limit)-1)*limit),
+		header(u, "last", limit, lastOffset),
+	}, ",")
 
 }

--- a/pagination/header_test.go
+++ b/pagination/header_test.go
@@ -1,9 +1,9 @@
 package pagination
 
 import (
-	"net/http"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -16,12 +16,10 @@ func TestHeader(t *testing.T) {
 	t.Run("Create previous and first but not next or last if at the end", func(t *testing.T) {
 		h := Header(u, 120, 50, 100)
 
-		expect := http.Header{
-			"Link": []string{
-				"<http://example.com?limit=50&offset=0>; rel=\"first\"",
-				"<http://example.com?limit=50&offset=50>; rel=\"prev\"",
-			},
-		}
+		expect := strings.Join([]string{
+			"<http://example.com?limit=50&offset=0>; rel=\"first\"",
+			"<http://example.com?limit=50&offset=50>; rel=\"prev\"",
+		}, ",")
 
 		if reflect.DeepEqual(expect, h) != true {
 			t.Fatalf("Unexpected response from Header. Expected %+v, got %+v", expect, h)
@@ -31,12 +29,10 @@ func TestHeader(t *testing.T) {
 	t.Run("Create next and last, but not previous or first if at the beginning", func(t *testing.T) {
 		h := Header(u, 120, 50, 0)
 
-		expect := http.Header{
-			"Link": []string{
-				"<http://example.com?limit=50&offset=50>; rel=\"next\"",
-				"<http://example.com?limit=50&offset=100>; rel=\"last\"",
-			},
-		}
+		expect := strings.Join([]string{
+			"<http://example.com?limit=50&offset=50>; rel=\"next\"",
+			"<http://example.com?limit=50&offset=100>; rel=\"last\"",
+		}, ",")
 
 		if reflect.DeepEqual(expect, h) != true {
 			t.Fatalf("Unexpected response from Header. Expected %+v, got %+v", expect, h)
@@ -46,12 +42,10 @@ func TestHeader(t *testing.T) {
 	t.Run("Create next and last, but not previous or first if on the first page", func(t *testing.T) {
 		h := Header(u, 120, 50, 10)
 
-		expect := http.Header{
-			"Link": []string{
-				"<http://example.com?limit=50&offset=50>; rel=\"next\"",
-				"<http://example.com?limit=50&offset=100>; rel=\"last\"",
-			},
-		}
+		expect := strings.Join([]string{
+			"<http://example.com?limit=50&offset=50>; rel=\"next\"",
+			"<http://example.com?limit=50&offset=100>; rel=\"last\"",
+		}, ",")
 
 		if reflect.DeepEqual(expect, h) != true {
 			t.Fatalf("Unexpected response from Header. Expected %+v, got %+v", expect, h)
@@ -61,31 +55,27 @@ func TestHeader(t *testing.T) {
 	t.Run("Create previous, next, first, and last if in the middle", func(t *testing.T) {
 		h := Header(u, 300, 50, 150)
 
-		expect := http.Header{
-			"Link": []string{
-				"<http://example.com?limit=50&offset=0>; rel=\"first\"",
-				"<http://example.com?limit=50&offset=200>; rel=\"next\"",
-				"<http://example.com?limit=50&offset=100>; rel=\"prev\"",
-				"<http://example.com?limit=50&offset=250>; rel=\"last\"",
-			},
-		}
+		expect := strings.Join([]string{
+			"<http://example.com?limit=50&offset=0>; rel=\"first\"",
+			"<http://example.com?limit=50&offset=200>; rel=\"next\"",
+			"<http://example.com?limit=50&offset=100>; rel=\"prev\"",
+			"<http://example.com?limit=50&offset=250>; rel=\"last\"",
+		}, ",")
 
-		if expect.Get("Link") != h.Get("Link") {
-			t.Fatalf("Unexpected response from Header. Expected %+v, got %+v", expect.Get("Link"), h.Get("Link"))
+		if expect != h {
+			t.Fatalf("Unexpected response from Header. Expected %+v, got %+v", expect, h)
 		}
 	})
 
 	t.Run("Header should default limit to 1 no limit was provided", func(t *testing.T) {
 		h := Header(u, 100, 0, 20)
 
-		expect := http.Header{
-			"Link": []string{
-				"<http://example.com?limit=1&offset=0>; rel=\"first\"",
-				"<http://example.com?limit=1&offset=21>; rel=\"next\"",
-				"<http://example.com?limit=1&offset=19>; rel=\"prev\"",
-				"<http://example.com?limit=1&offset=99>; rel=\"last\"",
-			},
-		}
+		expect := strings.Join([]string{
+			"<http://example.com?limit=1&offset=0>; rel=\"first\"",
+			"<http://example.com?limit=1&offset=21>; rel=\"next\"",
+			"<http://example.com?limit=1&offset=19>; rel=\"prev\"",
+			"<http://example.com?limit=1&offset=99>; rel=\"last\"",
+		}, ",")
 
 		if reflect.DeepEqual(expect, h) != true {
 			t.Fatalf("Unexpected response from Header. Expected %+v, got %+v", expect, h)
@@ -95,13 +85,11 @@ func TestHeader(t *testing.T) {
 	t.Run("Create previous, next, first, but not last if in the middle and no total was provided", func(t *testing.T) {
 		h := Header(u, 0, 50, 150)
 
-		expect := http.Header{
-			"Link": []string{
-				"<http://example.com?limit=50&offset=0>; rel=\"first\"",
-				"<http://example.com?limit=50&offset=200>; rel=\"next\"",
-				"<http://example.com?limit=50&offset=100>; rel=\"prev\"",
-			},
-		}
+		expect := strings.Join([]string{
+			"<http://example.com?limit=50&offset=0>; rel=\"first\"",
+			"<http://example.com?limit=50&offset=200>; rel=\"next\"",
+			"<http://example.com?limit=50&offset=100>; rel=\"prev\"",
+		}, ",")
 
 		if reflect.DeepEqual(expect, h) != true {
 			t.Fatalf("Unexpected response from Header. Expected %+v, got %+v", expect, h)


### PR DESCRIPTION
Signed-off-by: Kevin Minehart <kmineh0151@gmail.com>

## Related issue

A preliminary fix for https://github.com/ory/hydra/issues/1361

## Checklist


- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)

## Further comments

Took @aeneasr's advice and returned a string instead of an http.Header / map, as they are hard to work with.

I assumed Write would work, but I probably shouldn't have.