### PR TITLE
Fix the DB username can't contain "@" character

### DIFF
--- a/sqlcon/connector.go
+++ b/sqlcon/connector.go
@@ -196,7 +196,7 @@ func connectionString(clean *url.URL) string {
 	userinfo := username
 	password, hasPassword := clean.User.Password()
 	if hasPassword {
-		userinfo = url.QueryEscape(userinfo) + ":" + url.QueryEscape(password)
+		userinfo = userinfo + ":" + password
 	}
 	clean.User = nil
 	u := clean.String()

--- a/sqlcon/connector.go
+++ b/sqlcon/connector.go
@@ -196,7 +196,11 @@ func connectionString(clean *url.URL) string {
 	userinfo := username
 	password, hasPassword := clean.User.Password()
 	if hasPassword {
-		userinfo = userinfo + ":" + password
+		if clean.Scheme == "mysql" {
+			userinfo = userinfo + ":" + password
+		} else {
+			userinfo = url.QueryEscape(userinfo) + ":" + url.QueryEscape(password)
+		}
 	}
 	clean.User = nil
 	u := clean.String()


### PR DESCRIPTION
If  user name of DB contains"@" char, the sqlcon can't connect to the DB.
The DSN example is as following:
DSN=mysql://sa@test.mysql.database.azure.com:MyPassword@(127.0.0.1:3306)/hydra

This PR do a very simple fix.