### PR TITLE
fix username&password exposed when dsn's schema is mysql

### DIFF
--- a/sqlcon/connector.go
+++ b/sqlcon/connector.go
@@ -125,7 +125,12 @@ func (c *SQLConnection) GetDatabase() (*sqlx.DB, error) {
 		return nil, err
 	}
 
-	classifiedDSN := classifyDSN(dsn)
+	// fulfil classifyDSN()'s format, which must starts with schema://
+	dsnToClassify := dsn
+	if driverName == "mysql" {
+		dsnToClassify = "mysql://" + strings.TrimPrefix(dsnToClassify, "mysql://")
+	}
+	classifiedDSN := classifyDSN(dsnToClassify)
 	c.L.WithField("dsn", classifiedDSN).Info("Establishing connection with SQL database backend")
 
 	db, err := sql.Open(driverName, dsn)


### PR DESCRIPTION
If dsn starts with "mysql://", the sqlcon will expose username&password unsafety.
Before
```go
// c.DSN is
// mysql://root:root@tcp(localhost:32777)/shield?max_conns=20&max_idle_conns=4

dsn, err := connectionString(c.DSN) 
// dsn is
// root:root@tcp(localhost:32777)/shield?parseTime=true

classifiedDSN := classifyDSN(dsn)
// classifiedDSN is
// root:root@tcp(localhost:32777)/shield?parseTime=true://*:*@tcp(localhost:32777)/shield?parseTime=true
```
After
```go
// c.DSN is
// mysql://root:root@tcp(localhost:32777)/shield?max_conns=20&max_idle_conns=4

dsn, err := connectionString(c.DSN) 
// dsn is
// root:root@tcp(localhost:32777)/shield?parseTime=true

// fulfil classifyDSN()'s format, which must starts with schema://
dsnToClassify := dsn
if driverName == "mysql" {
	dsnToClassify = "mysql://" + strings.TrimPrefix(dsnToClassify, "mysql://")
}
classifiedDSN := classifyDSN(dsnToClassify)
// classifiedDSN is
// mysql://*:*@tcp(localhost:32777)/shield?parseTime=true
```

This PR do a very simple fix.