### PR TITLE
add helper method to get config with env vars

### DIFF
--- a/viperx/helper.go
+++ b/viperx/helper.go
@@ -164,23 +164,17 @@ func GetStringSlice(l logrus.FieldLogger, key string, fallback []string, depreca
 }
 
 // GetStringMapConfig returns a string map using all settings which will lookup env vars
-func GetStringMapConfig(prefix string, id string) map[string]interface{} {
-	allSettings := viper.AllSettings()
+func GetStringMapConfig(paths ...string) map[string]interface{} {
+	node := viper.AllSettings()
 
-	prefixSettings, ok := allSettings[prefix].(map[string]interface{})
-	if !ok {
-		return make(map[string]interface{})
+	for _, path := range paths {
+		subNode, ok := node[path].(map[string]interface{})
+		if !ok {
+			return make(map[string]interface{})
+		}
+
+		node = subNode
 	}
 
-	idSettings, ok := prefixSettings[id].(map[string]interface{})
-	if !ok {
-		return make(map[string]interface{})
-	}
-
-	config, ok := idSettings["config"]
-	if config == nil || !ok {
-		return make(map[string]interface{})
-	}
-
-	return config.(map[string]interface{})
+	return node
 }

--- a/viperx/helper.go
+++ b/viperx/helper.go
@@ -162,3 +162,25 @@ func GetStringSlice(l logrus.FieldLogger, key string, fallback []string, depreca
 
 	return r
 }
+
+// GetStringMapConfig returns a string map using all settings which will lookup env vars
+func GetStringMapConfig(prefix string, id string) map[string]interface{} {
+	allSettings := viper.AllSettings()
+
+	prefixSettings, ok := allSettings[prefix].(map[string]interface{})
+	if !ok {
+		return make(map[string]interface{})
+	}
+
+	idSettings, ok := prefixSettings[id].(map[string]interface{})
+	if !ok {
+		return make(map[string]interface{})
+	}
+
+	config, ok := idSettings["config"]
+	if config == nil || !ok {
+		return make(map[string]interface{})
+	}
+
+	return config.(map[string]interface{})
+}

--- a/viperx/helper_test.go
+++ b/viperx/helper_test.go
@@ -393,7 +393,7 @@ func TestGetStringMapConfig(t *testing.T) {
 					})
 				} else {
 					InitializeConfig("project-stub-name", "", l)
-					config := GetStringMapConfig("authenticators", "oauth2_introspection")
+					config := GetStringMapConfig("authenticators", "oauth2_introspection", "config")
 
 					assert.Equal(t, "http://myurl", config["introspection_url"])
 				}
@@ -423,7 +423,7 @@ func TestGetStringMapConfig(t *testing.T) {
 					})
 				} else {
 					InitializeConfig("project-stub-name", "", l)
-					config := GetStringMapConfig("authenticators", "oauth2_introspection")
+					config := GetStringMapConfig("authenticators", "oauth2_introspection", "config")
 
 					assert.Equal(t, "http://envurl", config["introspection_url"])
 				}

--- a/viperx/helper_test.go
+++ b/viperx/helper_test.go
@@ -397,6 +397,8 @@ func TestGetStringMapConfig(t *testing.T) {
 
 					assert.Equal(t, "http://myurl", config["introspection_url"])
 				}
+
+				cfgFile = ""
 			})
 		}
 	})
@@ -414,7 +416,8 @@ func TestGetStringMapConfig(t *testing.T) {
 		} {
 			t.Run(fmt.Sprintf("case=%d/path=%s", k, tc.f), func(t *testing.T) {
 				viper.Reset()
-				viper.Set("authenticators.oauth2_introspection.config.introspection_url", "http://envurl")
+
+				os.Setenv("AUTHENTICATORS_OAUTH2_INTROSPECTION_CONFIG_INTROSPECTION_URL", "http://envurl")
 
 				cfgFile = tc.f
 				if tc.fatals {
@@ -427,6 +430,8 @@ func TestGetStringMapConfig(t *testing.T) {
 
 					assert.Equal(t, "http://envurl", config["introspection_url"])
 				}
+
+				cfgFile = ""
 			})
 		}
 	})

--- a/viperx/stub/json/.project-stub-name.json
+++ b/viperx/stub/json/.project-stub-name.json
@@ -3,5 +3,12 @@
     "admin": {
       "port": 1
     }
+  },
+  "authenticators": {
+    "oauth2_introspection": {
+      "config":{
+        "introspection_url":"http://myurl"
+      }
+    }
   }
 }

--- a/viperx/stub/toml/.project-stub-name.toml
+++ b/viperx/stub/toml/.project-stub-name.toml
@@ -2,3 +2,8 @@
 
   [serve.admin]
   port = "2"
+
+[authenticators]
+
+  [authenticators.oauth2_introspection.config]
+  introspection_url = "http://myurl"

--- a/viperx/stub/yaml/.project-stub-name.yaml
+++ b/viperx/stub/yaml/.project-stub-name.yaml
@@ -2,3 +2,7 @@
 serve:
   admin:
     port: 3
+authenticators:
+  oauth2_introspection:
+    config:
+      introspection_url: http://myurl    

--- a/viperx/stub/yml/.project-stub-name.yml
+++ b/viperx/stub/yml/.project-stub-name.yml
@@ -1,3 +1,7 @@
 serve:
   admin:
     port: 4
+authenticators:
+  oauth2_introspection:
+    config:
+      introspection_url: http://myurl


### PR DESCRIPTION
## Related issue

https://github.com/ory/oathkeeper/issues/305

## Proposed changes

Helper method that uses viper.AllSettings which will do env var replace since viper.GetStringMap does not.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
