### PR TITLE
add abiltity to specify timeout when creating client

### DIFF
--- a/httpx/resilient_client.go
+++ b/httpx/resilient_client.go
@@ -61,3 +61,16 @@ func NewResilientClientLatencyToleranceExtreme(rt http.RoundTripper) *http.Clien
 		Transport: transport,
 	}
 }
+
+// NewResilientClientLatencyToleranceConfigurable creates a new http.Client for environments with configurable latency tolerance.
+// If transport is set (not nil) it will be wrapped by NewDefaultResilientRoundTripper.
+func NewResilientClientLatencyToleranceConfigurable(rt http.RoundTripper, timeout time.Duration, backOffDieAfter time.Duration) *http.Client {
+	transport := NewDefaultResilientRoundTripper(timeout, backOffDieAfter)
+	if rt != nil {
+		transport = NewResilientRoundTripper(rt, timeout, backOffDieAfter)
+	}
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}
+}


### PR DESCRIPTION
## Related issue

https://github.com/ory/oathkeeper/issues/310

## Proposed changes

Allow timeout to be configurable

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)

