### PR TITLE
fix(viperx): multiple validation errors

### DIFF
--- a/viperx/stub/config.schema.json
+++ b/viperx/stub/config.schema.json
@@ -6,6 +6,9 @@
   "properties": {
     "dsn": {
       "type": "string"
+    },
+    "foo": {
+      "const": "bar"
     }
   },
   "required": [

--- a/viperx/validate_test.go
+++ b/viperx/validate_test.go
@@ -92,8 +92,7 @@ func TestLoggerWithValidationErrorFields(t *testing.T) {
 		require.Error(t, err)
 
 		LoggerWithValidationErrorFields(l, err).WithError(err).Print("")
-		assert.EqualValues(t, "dsn", gjson.Get(buf.String(), "config_key").String(), "%s", buf.String())
-		assert.EqualValues(t, "one or more required properties are missing", gjson.Get(buf.String(), "validation_error").String(), "%s", buf.String())
+		assert.EqualValues(t, "one or more required properties are missing", gjson.Get(buf.String(), "\\[config_key=dsn\\]").String(), "%s", buf.String())
 	})
 
 	t.Run("case=type", func(t *testing.T) {
@@ -105,8 +104,7 @@ func TestLoggerWithValidationErrorFields(t *testing.T) {
 		require.Error(t, err)
 
 		LoggerWithValidationErrorFields(l, err).WithError(err).Print("")
-		assert.EqualValues(t, "dsn", gjson.Get(buf.String(), "config_key").String(), "%s", buf.String())
-		assert.EqualValues(t, "expected string, but got number", gjson.Get(buf.String(), "validation_error").String(), "%s", buf.String())
+		assert.EqualValues(t, "expected string, but got number", gjson.Get(buf.String(), "\\[config_key=dsn\\]").String(), "%s", buf.String())
 	})
 
 	t.Run("case=multiple errors", func(t *testing.T) {

--- a/viperx/validate_test.go
+++ b/viperx/validate_test.go
@@ -2,6 +2,7 @@ package viperx
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -95,7 +96,7 @@ func TestLoggerWithValidationErrorFields(t *testing.T) {
 		assert.EqualValues(t, "one or more required properties are missing", gjson.Get(buf.String(), "validation_error").String(), "%s", buf.String())
 	})
 
-	t.Run("case=required", func(t *testing.T) {
+	t.Run("case=type", func(t *testing.T) {
 		viper.Reset()
 		l, buf := nl()
 
@@ -106,5 +107,37 @@ func TestLoggerWithValidationErrorFields(t *testing.T) {
 		LoggerWithValidationErrorFields(l, err).WithError(err).Print("")
 		assert.EqualValues(t, "dsn", gjson.Get(buf.String(), "config_key").String(), "%s", buf.String())
 		assert.EqualValues(t, "expected string, but got number", gjson.Get(buf.String(), "validation_error").String(), "%s", buf.String())
+	})
+
+	t.Run("case=multiple errors", func(t *testing.T) {
+		viper.Reset()
+		l, buf := nl()
+
+		viper.Set("dsn", 1234)
+		viper.Set("foo", 1234)
+		err := ValidateFromURL("file://stub/config.schema.json")
+		require.Error(t, err)
+
+		expected := []struct {
+			key string
+			err string
+		}{
+			{
+				key: "dsn",
+				err: "expected string, but got number",
+			},
+			{
+				key: "foo",
+				err: "value must be \"bar\"",
+			},
+		}
+		LoggerWithValidationErrorFields(l, err).WithError(err).Print("")
+		jsonString := buf.String()
+		assert.Equal(t, "validation failed", gjson.Get(jsonString, "\\[config_key=#\\]").String(), "%s", jsonString)
+		for _, e := range expected {
+			assert.EqualValues(t, e.err, gjson.Get(jsonString, fmt.Sprintf("\\[config_key=%s\\]", e.key)).String(), "%s", jsonString)
+			assert.Contains(t, gjson.Get(jsonString, "error").String(), e.key, "%s", jsonString)
+			assert.Contains(t, gjson.Get(jsonString, "error").String(), e.err, "%s", jsonString)
+		}
 	})
 }


### PR DESCRIPTION
## Proposed changes
All validation error fields will be present in the output log. Until now only the last error was logged.
Also I changed the key format to not include the index because the order was not deterministic.