### PR TITLE
fix: Tracing logging with request logging

### DIFF
--- a/logrusx/helper.go
+++ b/logrusx/helper.go
@@ -80,7 +80,7 @@ func (l *Logger) WithRequest(r *http.Request) *Logger {
 		if spanCtx.HasSpanID() {
 			traces["span_id"] = spanCtx.SpanID.String()
 		}
-		ll = l.WithField("otel", traces)
+		ll = ll.WithField("otel", traces)
 	}
 
 	return ll


### PR DESCRIPTION
## Proposed changes

Currently, `http_request` is lost when `otel` is add.

like this

```
{"level":"info","msg":"started handling request","otel":{"span_id":"00f067aa0ba902b7","trace_id":"4bf92f3577b34da6a3ce929d0e0e4736"},"span_id":"00f067aa0ba902b7","time":"2020-06-11T09:51:23+09:00","trace_id":"4bf92f3577b34da6a3ce929d0e0e4736"}
{"audience":"application","error":{"message":"invalid_request","reason":"The POST body can not be empty.","status":"Bad Request","status_code":400},"level":"error","msg":"An error occurred","otel":{"span_id":"00f067aa0ba902b7","trace_id":"4bf92f3577b34da6a3ce929d0e0e4736"},"service_name":"","service_version":"","span_id":"00f067aa0ba902b7","time":"2020-06-11T09:51:23+09:00","trace_id":"4bf92f3577b34da6a3ce929d0e0e4736"}
{"http_response":{"status":400,"text_status":"Bad Request","took":299050},"level":"info","msg":"completed handling request","otel":{"span_id":"00f067aa0ba902b7","trace_id":"4bf92f3577b34da6a3ce929d0e0e4736"},"span_id":"00f067aa0ba902b7","time":"2020-06-11T09:51:23+09:00","trace_id":"4bf92f3577b34da6a3ce929d0e0e4736"}
```

So I fixed it.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
