### PR TITLE
fix: Rollback log format configuration

### DIFF
--- a/logrusx/logrus.go
+++ b/logrusx/logrus.go
@@ -33,7 +33,7 @@ func newLogger(o *options) *logrus.Logger {
 	if o.formatter != nil {
 		l.Formatter = o.formatter
 	} else {
-		switch stringsx.Coalesce(o.format, viper.GetString("log.formatter"), viper.GetString("LOG_FORMAT")) {
+		switch stringsx.Coalesce(o.format, viper.GetString("log.format"), viper.GetString("LOG_FORMAT")) {
 		case "json":
 			l.Formatter = &logrus.JSONFormatter{
 				PrettyPrint: l.IsLevelEnabled(logrus.DebugLevel),


### PR DESCRIPTION
## Proposed changes

Rollback log format configuration to `log.format` from `log.formatter` if unintentional. (because I couldn't find this change at CHANGELOG.md)
Environment variable is not changed because it remains `LOG_FORMAT`.

ref #155

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
