### PR TITLE
fix: removing whitespaces in config file path

### DIFF
--- a/viperx/stub/yml/.project-stub-name-invalid-path.yml
+++ b/viperx/stub/yml/.project-stub-name-invalid-path.yml
@@ -1,0 +1,7 @@
+serve:
+  admin:
+    port: 1
+authenticators:
+  oauth2_introspection:
+    config:
+      introspection_url: http://myurl

--- a/viperx/viper.go
+++ b/viperx/viper.go
@@ -111,7 +111,7 @@ func WatchConfig(l *logrusx.Logger, o *WatchOptions) {
 func InitializeConfig(applicationName string, homeOverride string, l *logrusx.Logger) *logrusx.Logger {
 	if cfgFile != "" {
 		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
+		viper.SetConfigFile(strings.TrimSpace(cfgFile))
 	} else {
 		// Find home directory.
 		home, err := homedir.Dir()

--- a/viperx/viper_test.go
+++ b/viperx/viper_test.go
@@ -72,6 +72,29 @@ func TestViperInit(t *testing.T) {
 		}
 	})
 
+	t.Run("suite=with-invalid-config-path", func(t *testing.T) {
+		for k, tc := range []struct {
+			f      string
+			fatals bool
+		}{
+			{f: " ./stub/yml/.project-stub-name-invalid-path.yml"},
+		} {
+			t.Run(fmt.Sprintf("case=%d/path=%s", k, tc.f), func(t *testing.T) {
+				viper.Reset()
+
+				cfgFile = tc.f
+				if tc.fatals {
+					assert.Panics(t, func() {
+						InitializeConfig("project-stub-name-invalid-path", "", l)
+					})
+				} else {
+					InitializeConfig("project-stub-name", "", l)
+					assert.Equal(t, k+1, viper.GetInt("serve.admin.port"))
+				}
+			})
+		}
+	})
+
 	t.Run("suite=os-env", func(t *testing.T) {
 		for k, tc := range []struct {
 			n string


### PR DESCRIPTION
## Proposed changes
This fixes simply trims whitespaces from the configuration file path if one has been specified -c // --config flag. 
This fixes a problem if you try to run e.g. Kratos and specify a custom configuration will with -c // --config flag without specifying each part of the commandline call as a seperate string literal: 

`kratos serve "-c ./myconfig.yml"`

fails with the following error message, although the file exists and the process has sufficient permissions to read the file:

`Unable to open config file. Make sure it exists and the process has sufficient permissions to read it  audience=application error=map[message:open  ./myconfig.yml: no such file or directory] path= ./contrib/quickstart/kratos/email-password/.kratos.yml service_name=kratos service_version=`

This is caused by the handling of flags as defined by https://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html, which results in a whitespace in the beginning of the config file path. 

As the error message is misleading and it is easy to overlook the whitespace in the error message, the fix simply removes whitespaces from the file path before it gets passed to viperx.



## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)

## Further comments
