### PR TITLE
feat: debug output all viper settings

### DIFF
--- a/mapx/type_assert_test.go
+++ b/mapx/type_assert_test.go
@@ -156,7 +156,7 @@ func TestGetInt(t *testing.T) {
 }
 
 func TestToJSONMap(t *testing.T) {
-	assert.EqualValues(t, map[string]interface {}{"baz":[]interface {}{map[string]interface {}{"bar":"bar"}}, "foo":"bar"},ToJSONMap(map[string]interface{}{
+	assert.EqualValues(t, map[string]interface{}{"baz": []interface{}{map[string]interface{}{"bar": "bar"}}, "foo": "bar"}, ToJSONMap(map[string]interface{}{
 		"foo": "bar",
 		"baz": []interface{}{
 			map[interface{}]interface{}{

--- a/viperx/validate.go
+++ b/viperx/validate.go
@@ -3,8 +3,9 @@ package viperx
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/ory/x/logrusx"
 	"io/ioutil"
+
+	"github.com/ory/x/logrusx"
 
 	"github.com/pkg/errors"
 

--- a/viperx/validate_test.go
+++ b/viperx/validate_test.go
@@ -2,12 +2,13 @@ package viperx
 
 import (
 	"bytes"
-	"github.com/ory/x/logrusx"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ory/x/logrusx"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"

--- a/viperx/vars.go
+++ b/viperx/vars.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 
-	"github.com/ory/viper"
 	"github.com/pkg/errors"
+
+	"github.com/ory/viper"
 
 	"github.com/ory/x/mapx"
 )

--- a/viperx/vars_test.go
+++ b/viperx/vars_test.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/ory/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ory/viper"
 )
 
 func TestUnmarshalKey(t *testing.T) {
@@ -14,7 +15,7 @@ func TestUnmarshalKey(t *testing.T) {
 	require.NoError(t, viper.ReadInConfig())
 
 	var config struct {
-		Enabled bool          `json:"enabled"`
+		Enabled bool            `json:"enabled"`
 		Config  json.RawMessage `json:"config"`
 	}
 	require.NoError(t, UnmarshalKey("selfservice.strategies.oidc", &config))

--- a/viperx/watch_and_validate_viper.go
+++ b/viperx/watch_and_validate_viper.go
@@ -12,7 +12,7 @@ import (
 )
 
 func WatchAndValidateViper(l *logrusx.Logger, schema []byte, productName string, immutables []string) {
-	if err := Validate("config.schema.json", schema); err != nil {
+	if err := Validate(l, "config.schema.json", schema); err != nil {
 		l.WithField("config_file", viper.ConfigFileUsed()).Error("The provided configuration is invalid and could not be loaded. Check the output below to understand why.")
 		_, _ = fmt.Fprintln(os.Stderr, "")
 		PrintHumanReadableValidationErrors(os.Stderr, err)
@@ -20,7 +20,7 @@ func WatchAndValidateViper(l *logrusx.Logger, schema []byte, productName string,
 	}
 
 	AddWatcher(func(event fsnotify.Event) error {
-		if err := Validate("config.schema.json", schema); err != nil {
+		if err := Validate(l, "config.schema.json", schema); err != nil {
 			PrintHumanReadableValidationErrors(os.Stderr, err)
 			l.Errorf("The changed configuration is invalid and could not be loaded. Rolling back to the last working configuration revision. Please address the validation errors before restarting %s.", productName)
 			return ErrRollbackConfigurationChanges


### PR DESCRIPTION
This feature contributes to our better-debug-output-offensive. It is especially usefull for users to note that a value is not actually set or set in a wrong way.
Also on config changes the whole config will now be printed making it possible to find all differences that occurred.
