### PR TITLE
fix: Functions to parse URLs and handle URL file paths

### DIFF
--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -1,0 +1,16 @@
+name: Windows go test
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - '*'
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: go test -failfast -timeout=20m ./...

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -13,4 +13,6 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - run: go test -failfast -timeout=20m ./...
+      - run: |
+          go test -failfast -timeout=20m $(go list ./... | grep -v viperx | grep -v watcherx | grep -v sqlcon)
+        shell: bash

--- a/urlx/parse.go
+++ b/urlx/parse.go
@@ -25,12 +25,10 @@ func Parse(rawURL string) (*url.URL, error) {
 		return url.Parse(rawURL)
 	}
 
-	if strings.HasPrefix(lcRawURL, "file://") {
-		// Normally the first part after file:// is a hostname, but since
-		// this is often misused we interpret the URL like a normal path
-		// by removing the "file://" from the beginning
-		rawURL = rawURL[7:]
-	}
+	// Normally the first part after file:// is a hostname, but since
+	// this is often misused we interpret the URL like a normal path
+	// by removing the "file://" from the beginning (if it exists)
+	rawURL = trimPrefixIC(rawURL, "file://")
 
 	if winPathRegex.MatchString(rawURL) {
 		// Windows path
@@ -46,11 +44,7 @@ func Parse(rawURL string) (*url.URL, error) {
 		return url.Parse("file://" + host + strings.ReplaceAll(path, "\\", "/"))
 	}
 
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return nil, err
-	}
-	return u, nil
+	return url.Parse(rawURL)
 }
 
 // ParseOrPanic parses a url or panics.
@@ -96,4 +90,14 @@ func extractUNCPathParts(uncPath string) (host, path string) {
 		path = "\\" + strings.Join(parts[1:], "\\")
 	}
 	return host, path
+}
+
+// trimPrefixIC returns s without the provided leading prefix string using
+// case insensitive matching.
+// If s doesn't start with prefix, s is returned unchanged.
+func trimPrefixIC(s, prefix string) string {
+	if strings.HasPrefix(strings.ToLower(s), prefix) {
+		return s[len(prefix):]
+	}
+	return s
 }

--- a/urlx/parse.go
+++ b/urlx/parse.go
@@ -13,7 +13,7 @@ var winPathRegex = regexp.MustCompile("^[A-Za-z]:.*")
 
 // Parse parses rawURL into a URL structure with special handling for file:// URLs
 // File URLs with relative paths (file://../file, ../file) will be returned as a
-// utl.URL object without the Scheme set to "file". This is because the file
+// url.URL object without the Scheme set to "file". This is because the file
 // scheme doesn't support relative paths. Make sure to check for
 // both "file" or "" (an empty string) in URL.Scheme if you are looking for
 // a file path.

--- a/urlx/parse.go
+++ b/urlx/parse.go
@@ -2,13 +2,67 @@ package urlx
 
 import (
 	"net/url"
+	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/ory/x/logrusx"
 )
 
+// winPathRegex is a regex for [DRIVE-LETTER]:
+var winPathRegex = regexp.MustCompile("^[A-Za-z]:.*")
+
+// Parse parses rawurl into a URL structure with special handling for file:// URLs
+// File URLs with relative paths (file://../file, ../file) will be returned as a
+// utl.URL object without the Scheme set to "file". This is because the file
+// scheme doesn't support relative paths. Make sure to check for
+// both "file" or "" (an empty string) in URL.Scheme if you are looking for
+// a file path.
+// Use the companion function GetURLFilePath() to get a file path suitable
+// for the current operaring system.
+func Parse(rawurl string) (*url.URL, error) {
+	lcRawurl := strings.ToLower(rawurl)
+	if strings.Index(lcRawurl, "file:///") == 0 {
+		return url.Parse("file:///" + toSlash(rawurl[8:]))
+	}
+	if strings.Index(lcRawurl, "file://") == 0 {
+		// Normally the first part after file:// is a hostname, but since
+		// this is often misused we interpret the URL like a normal path
+		// by removing the "file://" from the beginning
+		rawurl = rawurl[7:]
+	}
+	if winPathRegex.MatchString(rawurl) {
+		// Windows path
+		return url.Parse("file:///" + toSlash(rawurl))
+	}
+	if strings.Index(lcRawurl, "\\\\") == 0 {
+		// Windows UNC path
+		// We extract the hostname and creates an appropriate file:// URL
+		// based on the hostname and the path
+		parts := strings.Split(filepath.FromSlash(rawurl), "\\")
+		host := ""
+		if len(parts) > 2 {
+			host = parts[2]
+		}
+		p := "/"
+		if len(parts) > 4 {
+			p += strings.Join(parts[3:], "/")
+		}
+		return url.Parse("file://" + host + p)
+	}
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme == "file" || u.Scheme == "" {
+		u.Path = toSlash(u.Path)
+	}
+	return u, nil
+}
+
 // ParseOrPanic parses a url or panics.
 func ParseOrPanic(in string) *url.URL {
-	out, err := url.Parse(in)
+	out, err := Parse(in)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -17,7 +71,7 @@ func ParseOrPanic(in string) *url.URL {
 
 // ParseOrFatal parses a url or fatals.
 func ParseOrFatal(l *logrusx.Logger, in string) *url.URL {
-	out, err := url.Parse(in)
+	out, err := Parse(in)
 	if err != nil {
 		l.WithError(err).Fatalf("Unable to parse url: %s", in)
 	}
@@ -40,4 +94,8 @@ func ParseRequestURIOrFatal(l *logrusx.Logger, in string) *url.URL {
 		l.WithError(err).Fatalf("Unable to parse url: %s", in)
 	}
 	return out
+}
+
+func toSlash(path string) string {
+	return strings.ReplaceAll(path, "\\", "/")
 }

--- a/urlx/parse_test.go
+++ b/urlx/parse_test.go
@@ -1,0 +1,66 @@
+package urlx
+
+import (
+	"testing"
+
+	"github.com/ory/x/logrusx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse(t *testing.T) {
+	type testData struct {
+		urlStr       string
+		expectedPath string
+		expectedStr  string
+	}
+	var testURLs = []testData{
+		{"File:///home/test/file1.txt", "/home/test/file1.txt", "file:///home/test/file1.txt"},
+		{"fIle:/home/test/file2.txt", "/home/test/file2.txt", "file:///home/test/file2.txt"},
+		{"fiLe:///../test/update/file3.txt", "/../test/update/file3.txt", "file:///../test/update/file3.txt"},
+		{"filE://../test/update/file4.txt", "../test/update/file4.txt", "../test/update/file4.txt"},
+		{"file://C:/users/test/file5.txt", "/C:/users/test/file5.txt", "file:///C:/users/test/file5.txt"},  // We expect a initial / in the path because this is a Windows absolute path
+		{"file:///C:/users/test/file6.txt", "/C:/users/test/file6.txt", "file:///C:/users/test/file6.txt"}, // --//--
+		{"file://file7.txt", "file7.txt", "file7.txt"},
+		{"file://path/file8.txt", "path/file8.txt", "path/file8.txt"},
+		{"file://C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\9ccf9f68-121c-451a-8a73-2aa360925b5a386398343/access-rules.json", "/C:/Users/RUNNER~1/AppData/Local/Temp/9ccf9f68-121c-451a-8a73-2aa360925b5a386398343/access-rules.json", "file:///C:/Users/RUNNER~1/AppData/Local/Temp/9ccf9f68-121c-451a-8a73-2aa360925b5a386398343/access-rules.json"},
+		{"file:///C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\9ccf9f68-121c-451a-8a73-2aa360925b5a386398343/access-rules.json", "/C:/Users/RUNNER~1/AppData/Local/Temp/9ccf9f68-121c-451a-8a73-2aa360925b5a386398343/access-rules.json", "file:///C:/Users/RUNNER~1/AppData/Local/Temp/9ccf9f68-121c-451a-8a73-2aa360925b5a386398343/access-rules.json"},
+		{"file://C:\\Users\\path with space\\file.txt", "/C:/Users/path with space/file.txt", "file:///C:/Users/path%20with%20space/file.txt"},
+		{"file8b.txt", "file8b.txt", "file8b.txt"},
+		{"../file9.txt", "../file9.txt", "../file9.txt"},
+		{"./file9b.txt", "./file9b.txt", "./file9b.txt"},
+		{"file://./file9c.txt", "./file9c.txt", "./file9c.txt"},
+		{"file://./folder/.././file9d.txt", "./folder/.././file9d.txt", "./folder/.././file9d.txt"},
+		{"..\\file10.txt", "../file10.txt", "../file10.txt"},
+		{"C:\\file11.txt", "/C:/file11.txt", "file:///C:/file11.txt"},
+		{"\\\\hostname\\share\\file12.txt", "/share/file12.txt", "file://hostname/share/file12.txt"},
+		{"\\\\", "/", "file:///"},
+		{"\\\\hostname", "/", "file://hostname/"},
+		{"\\\\hostname\\", "/", "file://hostname/"},
+		{"file:///home/test/file 13.txt", "/home/test/file 13.txt", "file:///home/test/file%2013.txt"},
+		{"file:///home/test/file%2014.txt", "/home/test/file 14.txt", "file:///home/test/file%2014.txt"},
+		{"http://server:80/test/file%2015.txt", "/test/file 15.txt", "http://server:80/test/file%2015.txt"},
+	}
+
+	for _, td := range testURLs {
+		u, err := Parse(td.urlStr)
+		assert.NoError(t, err)
+		assert.Equal(t, td.expectedPath, u.Path, "expected path for %s", td.urlStr)
+		assert.Equal(t, td.expectedStr, u.String(), "expected URL string for %s", td.urlStr)
+	}
+
+	assert.Panics(t, func() {
+		ParseOrPanic("::")
+	})
+	assert.NotPanics(t, func() {
+		ParseOrPanic(testURLs[0].urlStr)
+	})
+	exitCode := 0
+	l := logrusx.New("", "", logrusx.WithExitFunc(func(c int) {
+		exitCode = c
+	}))
+	ParseOrFatal(l, "::")
+	assert.NotZero(t, exitCode, "ParseOrFatal should fail with a non zero exit code")
+	ParseOrFatal(l, testURLs[0].urlStr)
+	assert.NotZero(t, exitCode, "ParseOrFatal should not fail, zero exit code expected")
+
+}

--- a/urlx/parse_test.go
+++ b/urlx/parse_test.go
@@ -64,3 +64,19 @@ func TestParseURL(t *testing.T) {
 	_, err = Parse(":///path/file")
 	assert.Error(t, err)
 }
+
+func TestTrimPrefixIC(t *testing.T) {
+	for _, td := range []struct {
+		s        string
+		prefix   string
+		expected string
+	}{
+		{"file://test", "file://", "test"},
+		{"FILE://test", "file://", "test"},
+		{"FiLe://test", "file://", "test"},
+		{"http://test", "file://", "http://test"},
+		{"files://test", "file://", "files://test"},
+	} {
+		assert.Equal(t, td.expected, trimPrefixIC(td.s, td.prefix))
+	}
+}

--- a/urlx/path.go
+++ b/urlx/path.go
@@ -1,9 +1,9 @@
+// +build !windows
+
 package urlx
 
 import (
 	"net/url"
-	"path/filepath"
-	"runtime"
 )
 
 // GetURLFilePath returns the path of a URL that is compatible with the runtime os filesystem
@@ -11,30 +11,5 @@ func GetURLFilePath(u *url.URL) string {
 	if u == nil {
 		return ""
 	}
-
-	if u.Scheme != "file" && u.Scheme != "" {
-		return u.Path
-	}
-	fPath := u.Path
-	if runtime.GOOS == "windows" {
-		if u.Host != "" {
-			// Make UNC Path
-			s := string(filepath.Separator)
-			fPath = s + s + u.Host + filepath.FromSlash(fPath)
-			return fPath
-		}
-		if winPathRegex.MatchString(fPath[1:]) {
-			// On Windows we should remove the initial path separator in case this
-			// is a normal path (for example: "\c:\" -> "c:\"")
-			fPath = stripFistPathSeparators(fPath)
-		}
-	}
-	return filepath.FromSlash(fPath)
-}
-
-func stripFistPathSeparators(fPath string) string {
-	for len(fPath) > 0 && (fPath[0] == '/' || fPath[0] == '\\') {
-		fPath = fPath[1:]
-	}
-	return fPath
+	return u.Path
 }

--- a/urlx/path.go
+++ b/urlx/path.go
@@ -1,0 +1,40 @@
+package urlx
+
+import (
+	"net/url"
+	"path/filepath"
+	"runtime"
+)
+
+// GetURLFilePath returns the path of a URL that is compatible with the runtime os filesystem
+func GetURLFilePath(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+
+	if u.Scheme != "file" && u.Scheme != "" {
+		return u.Path
+	}
+	fPath := u.Path
+	if runtime.GOOS == "windows" {
+		if u.Host != "" {
+			// Make UNC Path
+			s := string(filepath.Separator)
+			fPath = s + s + u.Host + filepath.FromSlash(fPath)
+			return fPath
+		}
+		if winPathRegex.MatchString(fPath[1:]) {
+			// On Windows we should remove the initial path separator in case this
+			// is a normal path (for example: "\c:\" -> "c:\"")
+			fPath = stripFistPathSeparators(fPath)
+		}
+	}
+	return filepath.FromSlash(fPath)
+}
+
+func stripFistPathSeparators(fPath string) string {
+	for len(fPath) > 0 && (fPath[0] == '/' || fPath[0] == '\\') {
+		fPath = fPath[1:]
+	}
+	return fPath
+}

--- a/urlx/path_test.go
+++ b/urlx/path_test.go
@@ -1,0 +1,60 @@
+package urlx
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetURLFilePath(t *testing.T) {
+	type testData struct {
+		urlStr          string
+		expectedUnix    string
+		expectedWindows string
+		shouldSucceed   bool
+	}
+	var testURLs = []testData{
+		{"File:///home/test/file1.txt", "/home/test/file1.txt", "\\home\\test\\file1.txt", true},
+		{"fIle:/home/test/file2.txt", "/home/test/file2.txt", "\\home\\test\\file2.txt", true},
+		{"fiLe:///../test/update/file3.txt", "/../test/update/file3.txt", "\\..\\test\\update\\file3.txt", true},
+		{"filE://../test/update/file4.txt", "../test/update/file4.txt", "..\\test\\update\\file4.txt", true},
+		{"file://C:/users/test/file5.txt", "/C:/users/test/file5.txt", "C:\\users\\test\\file5.txt", true},
+		{"file:///C:/users/test/file5b.txt", "/C:/users/test/file5b.txt", "C:\\users\\test\\file5b.txt", true},
+		{"file://anotherhost/share/users/test/file6.txt", "/share/users/test/file6.txt", "\\\\anotherhost\\share\\users\\test\\file6.txt", false}, // this is not supported
+		{"file://file7.txt", "file7.txt", "file7.txt", true},
+		{"file://path/file8.txt", "path/file8.txt", "path\\file8.txt", true},
+		{"file://C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\9ccf9f68-121c-451a-8a73-2aa360925b5a386398343/access-rules.json", "/C:/Users/RUNNER~1/AppData/Local/Temp/9ccf9f68-121c-451a-8a73-2aa360925b5a386398343/access-rules.json", "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\9ccf9f68-121c-451a-8a73-2aa360925b5a386398343\\access-rules.json", true},
+		{"file:///C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\9ccf9f68-121c-451a-8a73-2aa360925b5a386398343/access-rules.json", "/C:/Users/RUNNER~1/AppData/Local/Temp/9ccf9f68-121c-451a-8a73-2aa360925b5a386398343/access-rules.json", "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\9ccf9f68-121c-451a-8a73-2aa360925b5a386398343\\access-rules.json", true},
+		{"file8.txt", "file8.txt", "file8.txt", true},
+		{"../file9.txt", "../file9.txt", "..\\file9.txt", true},
+		{"./file9b.txt", "./file9b.txt", ".\\file9b.txt", true},
+		{"file://./file9c.txt", "./file9c.txt", ".\\file9c.txt", true},
+		{"file://./folder/.././file9d.txt", "./folder/.././file9d.txt", ".\\folder\\..\\.\\file9d.txt", true},
+		{"..\\file10.txt", "../file10.txt", "..\\file10.txt", true},
+		{"C:\\file11.txt", "/C:/file11.txt", "C:\\file11.txt", true},
+		{"\\\\hostname\\share\\file12.txt", "/share/file12.txt", "\\\\hostname\\share\\file12.txt", true},
+		{"file:///home/test/file 13.txt", "/home/test/file 13.txt", "\\home\\test\\file 13.txt", true},
+		{"file:///home/test/file%2014.txt", "/home/test/file 14.txt", "\\home\\test\\file 14.txt", true},
+		{"http://server:80/test/file%2015.txt", "/test/file 15.txt", "/test/file 15.txt", true},
+	}
+	for _, td := range testURLs {
+		u, err := Parse(td.urlStr)
+		assert.NoError(t, err)
+		p := GetURLFilePath(u)
+		if runtime.GOOS == "windows" {
+			if td.shouldSucceed {
+				assert.Equal(t, td.expectedWindows, p)
+			} else {
+				assert.NotEqual(t, td.expectedWindows, p)
+			}
+		} else {
+			if td.shouldSucceed {
+				assert.Equal(t, td.expectedUnix, p)
+			} else {
+				assert.NotEqual(t, td.expectedUnix, p)
+			}
+		}
+	}
+	assert.Empty(t, GetURLFilePath(nil))
+}

--- a/urlx/path_test.go
+++ b/urlx/path_test.go
@@ -24,23 +24,34 @@ func TestGetURLFilePath(t *testing.T) {
 		{"file://anotherhost/share/users/test/file6.txt", "/share/users/test/file6.txt", "\\\\anotherhost\\share\\users\\test\\file6.txt", false}, // this is not supported
 		{"file://file7.txt", "file7.txt", "file7.txt", true},
 		{"file://path/file8.txt", "path/file8.txt", "path\\file8.txt", true},
-		{"file://C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\9ccf9f68-121c-451a-8a73-2aa360925b5a386398343/access-rules.json", "/C:/Users/RUNNER~1/AppData/Local/Temp/9ccf9f68-121c-451a-8a73-2aa360925b5a386398343/access-rules.json", "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\9ccf9f68-121c-451a-8a73-2aa360925b5a386398343\\access-rules.json", true},
-		{"file:///C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\9ccf9f68-121c-451a-8a73-2aa360925b5a386398343/access-rules.json", "/C:/Users/RUNNER~1/AppData/Local/Temp/9ccf9f68-121c-451a-8a73-2aa360925b5a386398343/access-rules.json", "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\9ccf9f68-121c-451a-8a73-2aa360925b5a386398343\\access-rules.json", true},
+		{"file://C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\9ccf9f68-121c-451a-8a73-2aa360925b5a386398343/access-rules.json", "/C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\9ccf9f68-121c-451a-8a73-2aa360925b5a386398343/access-rules.json", "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\9ccf9f68-121c-451a-8a73-2aa360925b5a386398343\\access-rules.json", true},
+		{"file:///C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\9ccf9f68-121c-451a-8a73-2aa360925b5a386398343/access-rules.json", "/C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\9ccf9f68-121c-451a-8a73-2aa360925b5a386398343/access-rules.json", "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\9ccf9f68-121c-451a-8a73-2aa360925b5a386398343\\access-rules.json", true},
 		{"file8.txt", "file8.txt", "file8.txt", true},
 		{"../file9.txt", "../file9.txt", "..\\file9.txt", true},
 		{"./file9b.txt", "./file9b.txt", ".\\file9b.txt", true},
 		{"file://./file9c.txt", "./file9c.txt", ".\\file9c.txt", true},
 		{"file://./folder/.././file9d.txt", "./folder/.././file9d.txt", ".\\folder\\..\\.\\file9d.txt", true},
-		{"..\\file10.txt", "../file10.txt", "..\\file10.txt", true},
-		{"C:\\file11.txt", "/C:/file11.txt", "C:\\file11.txt", true},
+		{"..\\file10.txt", "..\\file10.txt", "..\\file10.txt", true},
+		{"C:\\file11.txt", "/C:\\file11.txt", "C:\\file11.txt", true},
 		{"\\\\hostname\\share\\file12.txt", "/share/file12.txt", "\\\\hostname\\share\\file12.txt", true},
 		{"file:///home/test/file 13.txt", "/home/test/file 13.txt", "\\home\\test\\file 13.txt", true},
 		{"file:///home/test/file%2014.txt", "/home/test/file 14.txt", "\\home\\test\\file 14.txt", true},
 		{"http://server:80/test/file%2015.txt", "/test/file 15.txt", "/test/file 15.txt", true},
+		{"file:///dir/file\\ with backslash", "/dir/file\\ with backslash", "\\dir\\file\\ with backslash", true},
+		{"file://dir/file\\ with backslash", "dir/file\\ with backslash", "dir\\file\\ with backslash", true},
+		{"file:///dir/file with windows path forbidden chars \\<>:\"|%3F*", "/dir/file with windows path forbidden chars \\<>:\"|?*", "\\dir\\file with windows path forbidden chars \\<>:\"|?*", true},
+		{"file://dir/file with windows path forbidden chars \\<>:\"|%3F*", "dir/file with windows path forbidden chars \\<>:\"|?*", "dir\\file with windows path forbidden chars \\<>:\"|?*", true},
+		{"file:///path/file?query=1", "/path/file", "\\path\\file", true},
+		{"http://host:80/path/file?query=1", "/path/file", "/path/file", true},
+		{"file://////C:/file.txt", "////C:/file.txt", "C:\\file.txt", true},
+		{"file://////C:\\file.txt", "////C:\\file.txt", "C:\\file.txt", true},
 	}
 	for _, td := range testURLs {
 		u, err := Parse(td.urlStr)
 		assert.NoError(t, err)
+		if err != nil {
+			continue
+		}
 		p := GetURLFilePath(u)
 		if runtime.GOOS == "windows" {
 			if td.shouldSucceed {

--- a/urlx/path_windows.go
+++ b/urlx/path_windows.go
@@ -1,0 +1,33 @@
+// +build windows
+
+package urlx
+
+import (
+	"net/url"
+	"path/filepath"
+	"strings"
+)
+
+// GetURLFilePath returns the path of a URL that is compatible with the runtime os filesystem
+func GetURLFilePath(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	if !(u.Scheme == "file" || u.Scheme == "") {
+		return u.Path
+	}
+
+	fPath := u.Path
+	if u.Host != "" {
+		// Make UNC Path
+		fPath = "\\\\" + u.Host + filepath.FromSlash(fPath)
+		return fPath
+	}
+	fPathTrimmed := strings.TrimLeft(fPath, "/")
+	if winPathRegex.MatchString(fPathTrimmed) {
+		// On Windows we should remove the initial path separator in case this
+		// is a normal path (for example: "\c:\" -> "c:\"")
+		fPath = fPathTrimmed
+	}
+	return filepath.FromSlash(fPath)
+}


### PR DESCRIPTION
This code was first created for PR #557 in oathkeeper.
It should probably be in the shared ory/x project instead of there,
so that is why this code is checked in here.

## Related PR: https://github.com/ory/oathkeeper/pull/557

Related Ory person: @zepatrik 

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)

## Further comments

See other PR for more details