### PR TITLE
chore: run go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
 	github.com/tidwall/gjson v1.3.2
 	github.com/tidwall/sjson v1.0.4


### PR DESCRIPTION
## Related issue

`github.com/spf13/pflag v1.0.5` was missing in `go.mod`
