### PR TITLE
test: remove flakiness in reqlog test

### DIFF
--- a/reqlog/middleware_test.go
+++ b/reqlog/middleware_test.go
@@ -209,8 +209,10 @@ func TestRealClock_Since(t *testing.T) {
 	rc := &realClock{}
 	now := rc.Now()
 
-	time.Sleep(10 * time.Millisecond)
+	napDuration := 10 * time.Millisecond
+	time.Sleep(napDuration)
 	since := rc.Since(now)
 
-	assert.Regexp(t, "^1[0-5]\\.[0-9]+ms", since.String())
+	assert.True(t, since >= napDuration)
+	assert.True(t, since < napDuration+6*time.Millisecond)
 }


### PR DESCRIPTION

## Related issue
The test was failing [here](https://github.com/ory/x/pull/219/checks?check_run_id=1295947127) because the string representation was `10ms`, which the pattern would not allow. On the other hand it would allow `10.0ms`. Runs where e.g. the time would be exactly 11ms would also have failed the test by the way. Using comparison operators ensures that the whole range passes.

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->
