### PR TITLE
feat(viperx): Add support for parsing config passed through env vars as json

### DIFF
--- a/viperx/vars.go
+++ b/viperx/vars.go
@@ -28,13 +28,13 @@ func UnmarshalKey(key string, destination interface{}) error {
 			return errors.WithStack(err)
 		}
 
-		// Try decoding the json directly
+		// Try decoding the json directly. If it decodes successfully, return immediately.
 		if err := json.NewDecoder(&b).Decode(destination); err == nil {
 			return nil
 		}
 	}
 
-	// If it's not a string or not valid json, use the value as it was originally provided
+	// If it's not a string or not valid json, use the value as it was originally provided.
 	if err := json.NewEncoder(&b).Encode(mapx.ToJSONMap(value)); err != nil {
 		return errors.WithStack(err)
 	}

--- a/viperx/vars.go
+++ b/viperx/vars.go
@@ -20,8 +20,24 @@ func UnmarshalKey(key string, destination interface{}) error {
 	}
 
 	var b bytes.Buffer
-	if err := json.NewEncoder(&b).Encode(mapx.ToJSONMap(viper.Get(key))); err != nil {
+
+	// This may be a string in the case where a value was provided via an env var.
+	// If it's a string, try to decode it as json.
+	if v, ok := value.(string); ok {
+		if _, err := b.WriteString(v); err != nil {
+			return errors.WithStack(err)
+		}
+
+		// Try decoding the json directly
+		if err := json.NewDecoder(&b).Decode(destination); err == nil {
+			return nil
+		}
+	}
+
+	// If it's not a string or not valid json, use the value as it was originally provided
+	if err := json.NewEncoder(&b).Encode(mapx.ToJSONMap(value)); err != nil {
 		return errors.WithStack(err)
 	}
+
 	return errors.WithStack(json.NewDecoder(&b).Decode(destination))
 }

--- a/viperx/vars_test.go
+++ b/viperx/vars_test.go
@@ -23,3 +23,41 @@ func TestUnmarshalKey(t *testing.T) {
 	assert.EqualValues(t, true, config.Enabled)
 	assert.EqualValues(t, `{"providers":[{"client_id":"kratos-client","client_secret":"kratos-secret","id":"hydra","issuer_url":"http://127.0.0.1:4444/","mapper_url":"file://test/e2e/profiles/oidc/hydra.jsonnet","provider":"generic","scope":["offline"]},{"client_id":"google-client","client_secret":"kratos-secret","id":"google","issuer_url":"http://127.0.0.1:4444/","mapper_url":"file://test/e2e/profiles/oidc/hydra.jsonnet","provider":"generic","scope":["offline"]},{"client_id":"github-client","client_secret":"kratos-secret","id":"github","issuer_url":"http://127.0.0.1:4444/","mapper_url":"file://test/e2e/profiles/oidc/hydra.jsonnet","provider":"generic","scope":["offline"]}]}`, string(config.Config))
 }
+
+func TestUnmarshalKeyWithJsonObject(t *testing.T) {
+	viper.SetConfigFile("./stub/.unmarshal-key.yml")
+	viper.Set("selfservice.strategies.oidc", `{"enabled":true, "config":{"providers": [{"client_id":"a-different-client","client_secret":"a-different-secret","issuer_url":"http://127.0.0.1:4444/","mapper_url":"file://test/e2e/profiles/oidc/a-different-file.jsonnet","provider":"github","scope":["user:email"]}]}}`)
+	require.NoError(t, viper.ReadInConfig())
+
+	var config struct {
+		Enabled bool            `json:"enabled"`
+		Config  json.RawMessage `json:"config"`
+	}
+	require.NoError(t, UnmarshalKey("selfservice.strategies.oidc", &config))
+
+	assert.EqualValues(t, true, config.Enabled)
+	assert.EqualValues(t, `{"providers": [{"client_id":"a-different-client","client_secret":"a-different-secret","issuer_url":"http://127.0.0.1:4444/","mapper_url":"file://test/e2e/profiles/oidc/a-different-file.jsonnet","provider":"github","scope":["user:email"]}]}`, string(config.Config))
+}
+
+func TestUnmarshalKeyWithInvalidJson(t *testing.T) {
+	viper.SetConfigFile("./stub/.unmarshal-key.yml")
+	viper.Set("selfservice.strategies.oidc", `{"enabled":true, "config":{"providers": [{"client_id":"a-different-client",`)
+	require.NoError(t, viper.ReadInConfig())
+
+	var config struct {
+		Enabled bool            `json:"enabled"`
+		Config  json.RawMessage `json:"config"`
+	}
+	require.Error(t, UnmarshalKey("selfservice.strategies.oidc", &config))
+}
+
+func TestUnmarshalKeyWithString(t *testing.T) {
+	viper.SetConfigFile("./stub/.unmarshal-key.yml")
+	viper.Set("identity.default_schema_url", `https://ory.sh`)
+	require.NoError(t, viper.ReadInConfig())
+
+	var defaultSchemaURL string
+	require.NoError(t, UnmarshalKey("identity.default_schema_url", &defaultSchemaURL))
+
+	assert.EqualValues(t, `https://ory.sh`, defaultSchemaURL)
+}

--- a/viperx/vars_test.go
+++ b/viperx/vars_test.go
@@ -11,53 +11,56 @@ import (
 )
 
 func TestUnmarshalKey(t *testing.T) {
-	viper.SetConfigFile("./stub/.unmarshal-key.yml")
-	require.NoError(t, viper.ReadInConfig())
+	t.Run("case=Unmarshal a map from viper", func(t *testing.T) {
+		viper.SetConfigFile("./stub/.unmarshal-key.yml")
+		require.NoError(t, viper.ReadInConfig())
 
-	var config struct {
-		Enabled bool            `json:"enabled"`
-		Config  json.RawMessage `json:"config"`
-	}
-	require.NoError(t, UnmarshalKey("selfservice.strategies.oidc", &config))
+		var config struct {
+			Enabled bool            `json:"enabled"`
+			Config  json.RawMessage `json:"config"`
+		}
+		require.NoError(t, UnmarshalKey("selfservice.strategies.oidc", &config))
 
-	assert.EqualValues(t, true, config.Enabled)
-	assert.EqualValues(t, `{"providers":[{"client_id":"kratos-client","client_secret":"kratos-secret","id":"hydra","issuer_url":"http://127.0.0.1:4444/","mapper_url":"file://test/e2e/profiles/oidc/hydra.jsonnet","provider":"generic","scope":["offline"]},{"client_id":"google-client","client_secret":"kratos-secret","id":"google","issuer_url":"http://127.0.0.1:4444/","mapper_url":"file://test/e2e/profiles/oidc/hydra.jsonnet","provider":"generic","scope":["offline"]},{"client_id":"github-client","client_secret":"kratos-secret","id":"github","issuer_url":"http://127.0.0.1:4444/","mapper_url":"file://test/e2e/profiles/oidc/hydra.jsonnet","provider":"generic","scope":["offline"]}]}`, string(config.Config))
-}
+		assert.EqualValues(t, true, config.Enabled)
+		assert.EqualValues(t, `{"providers":[{"client_id":"kratos-client","client_secret":"kratos-secret","id":"hydra","issuer_url":"http://127.0.0.1:4444/","mapper_url":"file://test/e2e/profiles/oidc/hydra.jsonnet","provider":"generic","scope":["offline"]},{"client_id":"google-client","client_secret":"kratos-secret","id":"google","issuer_url":"http://127.0.0.1:4444/","mapper_url":"file://test/e2e/profiles/oidc/hydra.jsonnet","provider":"generic","scope":["offline"]},{"client_id":"github-client","client_secret":"kratos-secret","id":"github","issuer_url":"http://127.0.0.1:4444/","mapper_url":"file://test/e2e/profiles/oidc/hydra.jsonnet","provider":"generic","scope":["offline"]}]}`, string(config.Config))
+	})
 
-func TestUnmarshalKeyWithJsonObject(t *testing.T) {
-	viper.SetConfigFile("./stub/.unmarshal-key.yml")
-	viper.Set("selfservice.strategies.oidc", `{"enabled":true, "config":{"providers": [{"client_id":"a-different-client","client_secret":"a-different-secret","issuer_url":"http://127.0.0.1:4444/","mapper_url":"file://test/e2e/profiles/oidc/a-different-file.jsonnet","provider":"github","scope":["user:email"]}]}}`)
-	require.NoError(t, viper.ReadInConfig())
+	t.Run("case=Unmarshal a string containing a JSON object", func(t *testing.T) {
+		viper.SetConfigFile("./stub/.unmarshal-key.yml")
+		viper.Set("selfservice.strategies.oidc", `{"enabled":true, "config":{"providers": [{"client_id":"a-different-client","client_secret":"a-different-secret","issuer_url":"http://127.0.0.1:4444/","mapper_url":"file://test/e2e/profiles/oidc/a-different-file.jsonnet","provider":"github","scope":["user:email"]}]}}`)
+		require.NoError(t, viper.ReadInConfig())
 
-	var config struct {
-		Enabled bool            `json:"enabled"`
-		Config  json.RawMessage `json:"config"`
-	}
-	require.NoError(t, UnmarshalKey("selfservice.strategies.oidc", &config))
+		var config struct {
+			Enabled bool            `json:"enabled"`
+			Config  json.RawMessage `json:"config"`
+		}
+		require.NoError(t, UnmarshalKey("selfservice.strategies.oidc", &config))
 
-	assert.EqualValues(t, true, config.Enabled)
-	assert.EqualValues(t, `{"providers": [{"client_id":"a-different-client","client_secret":"a-different-secret","issuer_url":"http://127.0.0.1:4444/","mapper_url":"file://test/e2e/profiles/oidc/a-different-file.jsonnet","provider":"github","scope":["user:email"]}]}`, string(config.Config))
-}
+		assert.EqualValues(t, true, config.Enabled)
+		assert.EqualValues(t, `{"providers": [{"client_id":"a-different-client","client_secret":"a-different-secret","issuer_url":"http://127.0.0.1:4444/","mapper_url":"file://test/e2e/profiles/oidc/a-different-file.jsonnet","provider":"github","scope":["user:email"]}]}`, string(config.Config))
+	})
 
-func TestUnmarshalKeyWithInvalidJson(t *testing.T) {
-	viper.SetConfigFile("./stub/.unmarshal-key.yml")
-	viper.Set("selfservice.strategies.oidc", `{"enabled":true, "config":{"providers": [{"client_id":"a-different-client",`)
-	require.NoError(t, viper.ReadInConfig())
+	t.Run("case=Unmarshal a string containing invalid JSON", func(t *testing.T) {
+		viper.SetConfigFile("./stub/.unmarshal-key.yml")
+		viper.Set("selfservice.strategies.oidc", `{"enabled":true, "config":{"providers": [{"client_id":"a-different-client",`)
+		require.NoError(t, viper.ReadInConfig())
 
-	var config struct {
-		Enabled bool            `json:"enabled"`
-		Config  json.RawMessage `json:"config"`
-	}
-	require.Error(t, UnmarshalKey("selfservice.strategies.oidc", &config))
-}
+		var config struct {
+			Enabled bool            `json:"enabled"`
+			Config  json.RawMessage `json:"config"`
+		}
+		require.Error(t, UnmarshalKey("selfservice.strategies.oidc", &config))
+	})
 
-func TestUnmarshalKeyWithString(t *testing.T) {
-	viper.SetConfigFile("./stub/.unmarshal-key.yml")
-	viper.Set("identity.default_schema_url", `https://ory.sh`)
-	require.NoError(t, viper.ReadInConfig())
+	t.Run("case=Unmarshal a regular string", func(t *testing.T) {
+		viper.SetConfigFile("./stub/.unmarshal-key.yml")
+		viper.Set("identity.default_schema_url", `https://ory.sh`)
+		require.NoError(t, viper.ReadInConfig())
 
-	var defaultSchemaURL string
-	require.NoError(t, UnmarshalKey("identity.default_schema_url", &defaultSchemaURL))
+		var defaultSchemaURL string
+		require.NoError(t, UnmarshalKey("identity.default_schema_url", &defaultSchemaURL))
 
-	assert.EqualValues(t, `https://ory.sh`, defaultSchemaURL)
+		assert.EqualValues(t, `https://ory.sh`, defaultSchemaURL)
+	})
+
 }


### PR DESCRIPTION
## Related issue

@zepatrik as discussed in Slack

## Proposed changes

When setting up Kratos with Helm I would like to be able to configure some of the options via env vars rather than the config file because the values will contain sensitive data like client id / client secret.
This change will try to parse the values that come in to `UnmarshalKey` as JSON, and then falling back to the previous behaviour of encoding then decoding. Further comments below.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation within the code base (if appropriate).

## Further comments

This change will allow me to do something like setting an env var called `SELFSERVICE_METHODS_OIDC` containing a json object that specifies the value of the `oidc` struct. For the most part it shouldn't change the existing functionality around config parsing, except that anything passed via env var that is parseable as JSON now will be actually parsed.
As far as I can think of this shouldn't be a problem for the most part except in cases where someone might be trying to specify quotes or brackets in the value they are passing via env var, for example if they were doing something like `DSN="\"blahblah\"" kratos serve` and expecting to get the literal `"blahblah"`. After this change it would be parsed and the value would be `blahblah`.
Not sure if this edge case is significant. 