### PR TITLE
feat: add simple string switch case recorder

### DIFF
--- a/stringsx/switch_case.go
+++ b/stringsx/switch_case.go
@@ -1,0 +1,8 @@
+package stringsx
+
+type RegisteredCases []string
+
+func (r *RegisteredCases) AddCase(c string) string {
+	*r = append(*r, c)
+	return c
+}

--- a/stringsx/switch_case_test.go
+++ b/stringsx/switch_case_test.go
@@ -1,0 +1,38 @@
+package stringsx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegisteredCases(t *testing.T) {
+	t.Run("case=adds values", func(t *testing.T) {
+		v1, v2 := "value 1", "value 2"
+
+		cs := RegisteredCases{}
+		cs.AddCase(v1)
+		cs.AddCase(v2)
+
+		assert.Equal(t, RegisteredCases{v1, v2}, cs)
+	})
+
+	t.Run("case=returns value on add", func(t *testing.T) {
+		v1, v2 := "value 1", "value 2"
+
+		cs := RegisteredCases{}
+		assert.Equal(t, v1, cs.AddCase(v1))
+		assert.Equal(t, v2, cs.AddCase(v2))
+	})
+
+	t.Run("case=switch integration", func(t *testing.T) {
+		cases := RegisteredCases{}
+
+		switch "foo" {
+		case cases.AddCase("bar"):
+		case cases.AddCase("baz"):
+		}
+
+		assert.Equal(t, RegisteredCases{"bar", "baz"}, cases)
+	})
+}


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

This will allow the following:
```go
	knownExtensions := stringsx.RegisteredCases{}

	switch ext := filepath.Ext(fn); ext {
	case knownExtensions.AddCase("yaml"), knownExtensions.AddCase("yml"):
	case knownExtensions.AddCase("toml"):
	case knownExtensions.AddCase("json"):
	default:
		k.l.Errorf("Namespace file %s has an unknown file extension %s, expected one of %s.", fn, ext, knownExtensions)
	}
```