### PR TITLE
feat: add ErrUnknownCase to stringsx.RegisteredCases

### DIFF
--- a/stringsx/switch_case.go
+++ b/stringsx/switch_case.go
@@ -1,8 +1,42 @@
 package stringsx
 
-type RegisteredCases []string
+import (
+	"fmt"
+	"strings"
+)
+
+type (
+	RegisteredCases []string
+	errUnknownCase  struct {
+		cases  RegisteredCases
+		actual string
+	}
+)
+
+var ErrUnknownCase = errUnknownCase{}
 
 func (r *RegisteredCases) AddCase(c string) string {
 	*r = append(*r, c)
 	return c
+}
+
+func (r *RegisteredCases) String() string {
+	s := make([]string, len(*r))
+	for i, c := range *r {
+		s[i] = fmt.Sprintf("%#v", c)
+	}
+	return "[" + strings.Join(s, ", ") + "]"
+}
+
+func (r *RegisteredCases) ToUnknownCaseErr(actual string) error {
+	return errUnknownCase{cases: *r, actual: actual}
+}
+
+func (e errUnknownCase) Error() string {
+	return fmt.Sprintf("expected one of %s but got %s", e.cases.String(), e.actual)
+}
+
+func (e errUnknownCase) Is(err error) bool {
+	_, ok := err.(errUnknownCase)
+	return ok
 }

--- a/stringsx/switch_case_test.go
+++ b/stringsx/switch_case_test.go
@@ -1,6 +1,7 @@
 package stringsx
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,14 +26,37 @@ func TestRegisteredCases(t *testing.T) {
 		assert.Equal(t, v2, cs.AddCase(v2))
 	})
 
+	t.Run("case=converts to correct error", func(t *testing.T) {
+		c1, c2, actual := "case 1", "case 2", "actual"
+
+		cs := RegisteredCases{}
+		cs.AddCase(c1)
+		cs.AddCase(c2)
+
+		err := cs.ToUnknownCaseErr(actual)
+
+		assert.True(t, errors.Is(err, ErrUnknownCase))
+		assert.Equal(t, errUnknownCase{
+			cases:  cs,
+			actual: actual,
+		}, err)
+	})
+
 	t.Run("case=switch integration", func(t *testing.T) {
 		cases := RegisteredCases{}
+		var err error
 
-		switch "foo" {
+		switch f := "foo"; f {
 		case cases.AddCase("bar"):
 		case cases.AddCase("baz"):
+		default:
+			err = cases.ToUnknownCaseErr(f)
 		}
 
 		assert.Equal(t, RegisteredCases{"bar", "baz"}, cases)
+		assert.Equal(t, errUnknownCase{
+			cases:  cases,
+			actual: "foo",
+		}, err)
 	})
 }


### PR DESCRIPTION
Example usage:
```go
	knownFormats := stringsx.RegisteredCases{}
	switch ext := filepath.Ext(source); ext {
	case knownFormats.AddCase("yaml"), knownFormats.AddCase("yml"), knownFormats.AddCase("json"):
		parser = yaml.Unmarshal
	case knownFormats.AddCase("toml"):
		parser = toml.Unmarshal
	default:
		return nil, knownFormats.ToUnknownCaseErr(ext)
	}
```