### PR TITLE
feat(watcherx): allow requesting current data

### DIFF
--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -11,5 +11,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          go test -failfast -timeout=20m $(go list ./... | grep -v sqlcon)
+          go test -failfast -timeout=20m $(go list ./... | grep -v watcherx | grep -v sqlcon | grep -v configx)
         shell: bash

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -11,5 +11,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          go test -failfast -timeout=20m $(go list ./... | grep -v watcherx | grep -v sqlcon)
+          go test -failfast -timeout=20m $(go list ./... | grep -v sqlcon)
         shell: bash

--- a/configx/koanf_file.go
+++ b/configx/koanf_file.go
@@ -85,6 +85,6 @@ func (f *KoanfFile) Read() (map[string]interface{}, error) {
 
 // WatchChannel watches the file and triggers a callback when it changes. It is a
 // blocking function that internally spawns a goroutine to watch for changes.
-func (f *KoanfFile) WatchChannel(c watcherx.EventChannel) error {
+func (f *KoanfFile) WatchChannel(c watcherx.EventChannel) (watcherx.Watcher, error) {
 	return watcherx.WatchFile(f.ctx, f.path, c)
 }

--- a/configx/provider.go
+++ b/configx/provider.go
@@ -235,14 +235,13 @@ func (p *Provider) addConfigFile(ctx context.Context, path string, k *koanf.Koan
 				cancel()
 				cancel = cancelInner
 				p.runOnChanges(e, nil)
-				close(c)
 				span.Finish()
 				return
 			}
 		}
 	}(c)
 
-	if err := fp.WatchChannel(c); err != nil {
+	if _, err := fp.WatchChannel(c); err != nil {
 		close(c)
 		return err
 	}

--- a/configx/provider_watch_test.go
+++ b/configx/provider_watch_test.go
@@ -47,7 +47,6 @@ func updateConfigFile(t *testing.T, wg *sync.WaitGroup, configFile *os.File, dsn
 	require.NoError(t, err)
 	_, err = io.WriteString(configFile, config)
 	require.NoError(t, configFile.Sync())
-	require.NoError(t, configFile.Sync())
 }
 
 func TestReload(t *testing.T) {
@@ -59,7 +58,6 @@ func TestReload(t *testing.T) {
 		modifiers = append(modifiers,
 			WithLogrusWatcher(l),
 			AttachWatcher(func(event watcherx.Event, err error) {
-				fmt.Println("going to call done")
 				wg.Done()
 			}),
 			WithContext(ctx),
@@ -70,8 +68,6 @@ func TestReload(t *testing.T) {
 	}
 
 	t.Run("case=rejects not validating changes", func(t *testing.T) {
-		fmt.Println("case 1")
-
 		configFile := tmpConfigFile(t, "memory", "bar")
 		defer configFile.Close()
 		hook := test.NewLocal(l.Entry.Logger)
@@ -96,8 +92,6 @@ func TestReload(t *testing.T) {
 	})
 
 	t.Run("case=rejects to update immutable", func(t *testing.T) {
-		fmt.Println("case 2")
-
 		configFile := tmpConfigFile(t, "memory", "bar")
 		defer configFile.Close()
 		hook := test.NewLocal(l.Entry.Logger)
@@ -121,8 +115,6 @@ func TestReload(t *testing.T) {
 	})
 
 	t.Run("case=runs without validation errors", func(t *testing.T) {
-		fmt.Println("case 3")
-
 		configFile := tmpConfigFile(t, "some string", "bar")
 		defer configFile.Close()
 		hook := test.NewLocal(l.Entry.Logger)
@@ -135,8 +127,6 @@ func TestReload(t *testing.T) {
 	})
 
 	t.Run("case=has with validation errors", func(t *testing.T) {
-		fmt.Println("case 4")
-
 		configFile := tmpConfigFile(t, "some string", "not bar")
 		defer configFile.Close()
 		hook := test.NewLocal(l.Entry.Logger)

--- a/configx/provider_watch_test.go
+++ b/configx/provider_watch_test.go
@@ -58,6 +58,7 @@ func TestReload(t *testing.T) {
 		modifiers = append(modifiers,
 			WithLogrusWatcher(l),
 			AttachWatcher(func(event watcherx.Event, err error) {
+				t.Log("going to call done")
 				wg.Done()
 			}),
 			WithContext(ctx),

--- a/configx/provider_watch_test.go
+++ b/configx/provider_watch_test.go
@@ -47,6 +47,7 @@ func updateConfigFile(t *testing.T, wg *sync.WaitGroup, configFile *os.File, dsn
 	require.NoError(t, err)
 	_, err = io.WriteString(configFile, config)
 	require.NoError(t, configFile.Sync())
+	require.NoError(t, configFile.Sync())
 }
 
 func TestReload(t *testing.T) {
@@ -58,7 +59,7 @@ func TestReload(t *testing.T) {
 		modifiers = append(modifiers,
 			WithLogrusWatcher(l),
 			AttachWatcher(func(event watcherx.Event, err error) {
-				t.Log("going to call done")
+				fmt.Println("going to call done")
 				wg.Done()
 			}),
 			WithContext(ctx),
@@ -69,6 +70,8 @@ func TestReload(t *testing.T) {
 	}
 
 	t.Run("case=rejects not validating changes", func(t *testing.T) {
+		fmt.Println("case 1")
+
 		configFile := tmpConfigFile(t, "memory", "bar")
 		hook := test.NewLocal(l.Entry.Logger)
 		wg := new(sync.WaitGroup)
@@ -92,6 +95,8 @@ func TestReload(t *testing.T) {
 	})
 
 	t.Run("case=rejects to update immutable", func(t *testing.T) {
+		fmt.Println("case 2")
+
 		configFile := tmpConfigFile(t, "memory", "bar")
 		hook := test.NewLocal(l.Entry.Logger)
 		wg := new(sync.WaitGroup)
@@ -114,6 +119,8 @@ func TestReload(t *testing.T) {
 	})
 
 	t.Run("case=runs without validation errors", func(t *testing.T) {
+		fmt.Println("case 3")
+
 		configFile := tmpConfigFile(t, "some string", "bar")
 		hook := test.NewLocal(l.Entry.Logger)
 		wg := new(sync.WaitGroup)
@@ -125,6 +132,8 @@ func TestReload(t *testing.T) {
 	})
 
 	t.Run("case=has with validation errors", func(t *testing.T) {
+		fmt.Println("case 4")
+
 		configFile := tmpConfigFile(t, "some string", "not bar")
 		hook := test.NewLocal(l.Entry.Logger)
 

--- a/configx/provider_watch_test.go
+++ b/configx/provider_watch_test.go
@@ -73,6 +73,7 @@ func TestReload(t *testing.T) {
 		fmt.Println("case 1")
 
 		configFile := tmpConfigFile(t, "memory", "bar")
+		defer configFile.Close()
 		hook := test.NewLocal(l.Entry.Logger)
 		wg := new(sync.WaitGroup)
 		p := setup(t, configFile, wg)
@@ -98,6 +99,7 @@ func TestReload(t *testing.T) {
 		fmt.Println("case 2")
 
 		configFile := tmpConfigFile(t, "memory", "bar")
+		defer configFile.Close()
 		hook := test.NewLocal(l.Entry.Logger)
 		wg := new(sync.WaitGroup)
 		p := setup(t, configFile, wg,
@@ -122,6 +124,7 @@ func TestReload(t *testing.T) {
 		fmt.Println("case 3")
 
 		configFile := tmpConfigFile(t, "some string", "bar")
+		defer configFile.Close()
 		hook := test.NewLocal(l.Entry.Logger)
 		wg := new(sync.WaitGroup)
 		p := setup(t, configFile, wg)
@@ -135,6 +138,7 @@ func TestReload(t *testing.T) {
 		fmt.Println("case 4")
 
 		configFile := tmpConfigFile(t, "some string", "not bar")
+		defer configFile.Close()
 		hook := test.NewLocal(l.Entry.Logger)
 
 		var b bytes.Buffer

--- a/watcherx/definitions.go
+++ b/watcherx/definitions.go
@@ -11,10 +11,19 @@ type (
 		scheme string
 	}
 	EventChannel chan Event
+	Watcher      interface {
+		DispatchNow() error
+	}
+	dispatcher struct {
+		trigger chan struct{}
+	}
 )
 
-// ErrSchemeUnknown is just for checking with errors.Is()
-var ErrSchemeUnknown = &errSchemeUnknown{}
+var (
+	// ErrSchemeUnknown is just for checking with errors.Is()
+	ErrSchemeUnknown     = &errSchemeUnknown{}
+	ErrWatcherNotRunning = fmt.Errorf("watcher is not running")
+)
 
 func (e *errSchemeUnknown) Is(other error) bool {
 	_, ok := other.(*errSchemeUnknown)
@@ -25,12 +34,27 @@ func (e *errSchemeUnknown) Error() string {
 	return fmt.Sprintf("unknown scheme '%s' to watch", e.scheme)
 }
 
-func Watch(ctx context.Context, u *url.URL, c EventChannel) error {
+func newDispatcher() *dispatcher {
+	return &dispatcher{
+		trigger: make(chan struct{}),
+	}
+}
+
+func (d *dispatcher) DispatchNow() error {
+	if d.trigger == nil {
+		return ErrWatcherNotRunning
+	}
+	d.trigger <- struct{}{}
+	return nil
+}
+
+func Watch(ctx context.Context, u *url.URL, c EventChannel) (Watcher, error) {
 	switch u.Scheme {
-	case "file":
+	// see urlx.Parse for why the empty string is also file
+	case "file", "":
 		return WatchFile(ctx, u.Path, c)
 	case "ws":
 		return WatchWebsocket(ctx, u, c)
 	}
-	return &errSchemeUnknown{u.Scheme}
+	return nil, &errSchemeUnknown{u.Scheme}
 }

--- a/watcherx/directory_test.go
+++ b/watcherx/directory_test.go
@@ -135,7 +135,7 @@ func TestWatchDirectory(t *testing.T) {
 		_, err = WatchDirectory(ctx, dir, c)
 		require.NoError(t, err)
 
-		require.NoError(t, os.RemoveAll(childDir))
+		require.NoError(t, os.RemoveAll(childDir), "There is really a create file permission error here?")
 
 		events := []Event{<-c, <-c}
 		if events[0].Source() > events[1].Source() {

--- a/watcherx/directory_test.go
+++ b/watcherx/directory_test.go
@@ -135,7 +135,7 @@ func TestWatchDirectory(t *testing.T) {
 		_, err = WatchDirectory(ctx, dir, c)
 		require.NoError(t, err)
 
-		require.NoError(t, os.RemoveAll(childDir), "There is really a create file permission error here?")
+		require.NoError(t, os.RemoveAll(childDir))
 
 		events := []Event{<-c, <-c}
 		if events[0].Source() > events[1].Source() {

--- a/watcherx/file.go
+++ b/watcherx/file.go
@@ -2,6 +2,7 @@ package watcherx
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -89,6 +90,7 @@ func streamFileEvents(ctx context.Context, watcher *fsnotify.Watcher, c EventCha
 				close(c)
 				return
 			}
+			fmt.Printf("Got raw fsnotify event: %+v\n", e)
 			// filter events to only watch watchedFile
 			// e.Name contains the name of the watchedFile (regardless whether it is a symlink), not the resolved file name
 			if filepath.Clean(e.Name) == watchedFile {

--- a/watcherx/file.go
+++ b/watcherx/file.go
@@ -2,7 +2,6 @@ package watcherx
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -90,7 +89,6 @@ func streamFileEvents(ctx context.Context, watcher *fsnotify.Watcher, c EventCha
 				close(c)
 				return
 			}
-			fmt.Printf("Got raw fsnotify event: %+v\n", e)
 			// filter events to only watch watchedFile
 			// e.Name contains the name of the watchedFile (regardless whether it is a symlink), not the resolved file name
 			if filepath.Clean(e.Name) == watchedFile {

--- a/watcherx/file.go
+++ b/watcherx/file.go
@@ -1,30 +1,28 @@
 package watcherx
 
 import (
-	"bytes"
 	"context"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/pkg/errors"
 )
 
-func WatchFile(ctx context.Context, file string, c EventChannel) error {
-	w, err := fsnotify.NewWatcher()
+func WatchFile(ctx context.Context, file string, c EventChannel) (Watcher, error) {
+	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		return errors.WithStack(err)
+		return nil, errors.WithStack(err)
 	}
-	dir := path.Dir(file)
-	if err := w.Add(dir); err != nil {
-		return errors.WithStack(err)
+	dir := filepath.Dir(file)
+	if err := watcher.Add(dir); err != nil {
+		return nil, errors.WithStack(err)
 	}
 	resolvedFile, err := filepath.EvalSymlinks(file)
 	if err != nil {
 		if _, ok := err.(*os.PathError); !ok {
-			return errors.WithStack(err)
+			return nil, errors.WithStack(err)
 		}
 		// The file does not exist. The watcher should still watch the directory
 		// to get notified about file creation.
@@ -33,17 +31,18 @@ func WatchFile(ctx context.Context, file string, c EventChannel) error {
 		// If `resolvedFile` != `file` then `file` is a symlink and we have to explicitly watch the referenced file.
 		// This is because fsnotify follows symlinks and watches the destination file, not the symlink
 		// itself. That is at least the case for unix systems. See: https://github.com/fsnotify/fsnotify/issues/199
-		if err := w.Add(file); err != nil {
-			return errors.WithStack(err)
+		if err := watcher.Add(file); err != nil {
+			return nil, errors.WithStack(err)
 		}
 	}
-	go streamFileEvents(ctx, w, c, file, resolvedFile)
-	return nil
+	d := newDispatcher()
+	go streamFileEvents(ctx, watcher, c, d.trigger, file, resolvedFile)
+	return d, nil
 }
 
 // streamFileEvents watches for file changes and supports symlinks which requires several workarounds due to limitations of fsnotify.
 // Argument `resolvedFile` is the resolved symlink path of the file, or it is the watchedFile name itself. If `resolvedFile` is empty, then the watchedFile does not exist.
-func streamFileEvents(ctx context.Context, watcher *fsnotify.Watcher, c EventChannel, watchedFile, resolvedFile string) {
+func streamFileEvents(ctx context.Context, watcher *fsnotify.Watcher, c EventChannel, sendNow <-chan struct{}, watchedFile, resolvedFile string) {
 	eventSource := source(watchedFile)
 	removeDirectFileWatcher := func() {
 		_ = watcher.Remove(watchedFile)
@@ -64,15 +63,35 @@ func streamFileEvents(ctx context.Context, watcher *fsnotify.Watcher, c EventCha
 		select {
 		case <-ctx.Done():
 			_ = watcher.Close()
+			close(c)
 			return
+		case <-sendNow:
+			if resolvedFile == "" {
+				// The file does not exist. Announce this by sending a RemoveEvent.
+				c <- &RemoveEvent{eventSource}
+			} else {
+				// The file does exist. Announce the current content by sending a ChangeEvent.
+				data, err := ioutil.ReadFile(watchedFile)
+				if err != nil {
+					c <- &ErrorEvent{
+						error:  errors.WithStack(err),
+						source: eventSource,
+					}
+					continue
+				}
+				c <- &ChangeEvent{
+					data:   data,
+					source: eventSource,
+				}
+			}
 		case e, ok := <-watcher.Events:
 			if !ok {
-				_ = watcher.Close()
+				close(c)
 				return
 			}
 			// filter events to only watch watchedFile
 			// e.Name contains the name of the watchedFile (regardless whether it is a symlink), not the resolved file name
-			if path.Clean(e.Name) == watchedFile {
+			if filepath.Clean(e.Name) == watchedFile {
 				recentlyResolvedFile, err := filepath.EvalSymlinks(watchedFile)
 				// when there is no error the file exists and any symlinks can be resolved
 				if err != nil {
@@ -110,7 +129,7 @@ func streamFileEvents(ctx context.Context, watcher *fsnotify.Watcher, c EventCha
 						continue
 					}
 					c <- &ChangeEvent{
-						data:   bytes.NewBuffer(data),
+						data:   data,
 						source: eventSource,
 					}
 				}

--- a/watcherx/file_test.go
+++ b/watcherx/file_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -91,6 +92,10 @@ func TestFileWatcher(t *testing.T) {
 	})
 
 	t.Run("case=notifies about changes in the linked file", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("skipping test because watching symlinks on windows is not working properly")
+		}
+
 		ctx, c, dir, cancel := setup(t)
 		defer cancel()
 
@@ -114,6 +119,10 @@ func TestFileWatcher(t *testing.T) {
 	})
 
 	t.Run("case=notifies about symlink change", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("skipping test because watching symlinks on windows is not working properly")
+		}
+
 		ctx, c, dir, cancel := setup(t)
 		defer cancel()
 
@@ -176,6 +185,10 @@ func TestFileWatcher(t *testing.T) {
 	//})
 
 	t.Run("case=kubernetes atomic writer update", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("skipping test because watching symlinks on windows is not working properly")
+		}
+
 		ctx, c, dir, cancel := setup(t)
 		defer cancel()
 

--- a/watcherx/file_test.go
+++ b/watcherx/file_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,11 +38,12 @@ func TestFileWatcher(t *testing.T) {
 		ctx, c, dir, cancel := setup(t)
 		defer cancel()
 
-		exampleFile := path.Join(dir, "example.file")
+		exampleFile := filepath.Join(dir, "example.file")
 		f, err := os.Create(exampleFile)
 		require.NoError(t, err)
 
-		require.NoError(t, WatchFile(ctx, exampleFile, c))
+		_, err = WatchFile(ctx, exampleFile, c)
+		require.NoError(t, err)
 
 		_, err = fmt.Fprintf(f, "foo")
 		require.NoError(t, err)
@@ -55,8 +56,9 @@ func TestFileWatcher(t *testing.T) {
 		ctx, c, dir, cancel := setup(t)
 		defer cancel()
 
-		exampleFile := path.Join(dir, "example.file")
-		require.NoError(t, WatchFile(ctx, exampleFile, c))
+		exampleFile := filepath.Join(dir, "example.file")
+		_, err := WatchFile(ctx, exampleFile, c)
+		require.NoError(t, err)
 
 		f, err := os.Create(exampleFile)
 		require.NoError(t, err)
@@ -69,12 +71,13 @@ func TestFileWatcher(t *testing.T) {
 		ctx, c, dir, cancel := setup(t)
 		defer cancel()
 
-		exampleFile := path.Join(dir, "example.file")
+		exampleFile := filepath.Join(dir, "example.file")
 		f, err := os.Create(exampleFile)
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 
-		require.NoError(t, WatchFile(ctx, exampleFile, c))
+		_, err = WatchFile(ctx, exampleFile, c)
+		require.NoError(t, err)
 
 		require.NoError(t, os.Remove(exampleFile))
 
@@ -93,14 +96,15 @@ func TestFileWatcher(t *testing.T) {
 
 		otherDir, err := ioutil.TempDir("", "*")
 		require.NoError(t, err)
-		origFileName := path.Join(otherDir, "original")
+		origFileName := filepath.Join(otherDir, "original")
 		f, err := os.Create(origFileName)
 		require.NoError(t, err)
 
-		linkFileName := path.Join(dir, "slink")
+		linkFileName := filepath.Join(dir, "slink")
 		require.NoError(t, os.Symlink(origFileName, linkFileName))
 
-		require.NoError(t, WatchFile(ctx, linkFileName, c))
+		_, err = WatchFile(ctx, linkFileName, c)
+		require.NoError(t, err)
 
 		_, err = fmt.Fprintf(f, "content")
 		require.NoError(t, err)
@@ -115,8 +119,8 @@ func TestFileWatcher(t *testing.T) {
 
 		otherDir, err := ioutil.TempDir("", "*")
 		require.NoError(t, err)
-		fileOne := path.Join(otherDir, "fileOne")
-		fileTwo := path.Join(otherDir, "fileTwo")
+		fileOne := filepath.Join(otherDir, "fileOne")
+		fileTwo := filepath.Join(otherDir, "fileTwo")
 		f1, err := os.Create(fileOne)
 		require.NoError(t, err)
 		require.NoError(t, f1.Close())
@@ -126,10 +130,11 @@ func TestFileWatcher(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, f2.Close())
 
-		linkFileName := path.Join(dir, "slink")
+		linkFileName := filepath.Join(dir, "slink")
 		require.NoError(t, os.Symlink(fileOne, linkFileName))
 
-		require.NoError(t, WatchFile(ctx, linkFileName, c))
+		_, err = WatchFile(ctx, linkFileName, c)
+		require.NoError(t, err)
 
 		require.NoError(t, os.Remove(linkFileName))
 		assertRemove(t, <-c, linkFileName)
@@ -145,7 +150,8 @@ func TestFileWatcher(t *testing.T) {
 		require.NoError(t, os.Chdir(dir))
 
 		fileName := "example.file"
-		require.NoError(t, WatchFile(ctx, fileName, c))
+		_, err := WatchFile(ctx, fileName, c)
+		require.NoError(t, err)
 
 		f, err := os.Create(fileName)
 		require.NoError(t, err)
@@ -174,13 +180,29 @@ func TestFileWatcher(t *testing.T) {
 		defer cancel()
 
 		fileName := "example.file"
-		filePath := path.Join(dir, fileName)
+		filePath := filepath.Join(dir, fileName)
 		kubernetesAtomicWrite(t, dir, fileName, "foobar")
 
-		require.NoError(t, WatchFile(ctx, filePath, c))
+		_, err := WatchFile(ctx, filePath, c)
+		require.NoError(t, err)
 
 		kubernetesAtomicWrite(t, dir, fileName, "foobarx")
 
 		assertChange(t, <-c, "foobarx", filePath)
+	})
+
+	t.Run("case=sends event when requested", func(t *testing.T) {
+		ctx, c, dir, cancel := setup(t)
+		defer cancel()
+
+		fn := filepath.Join(dir, "example.file")
+		initialContent := "initial content"
+		require.NoError(t, ioutil.WriteFile(fn, []byte(initialContent), 0600))
+
+		d, err := WatchFile(ctx, fn, c)
+		require.NoError(t, err)
+		require.NoError(t, d.DispatchNow())
+
+		assertChange(t, <-c, initialContent, fn)
 	})
 }

--- a/watcherx/integrationtest/main.go
+++ b/watcherx/integrationtest/main.go
@@ -16,7 +16,7 @@ func main() {
 	}
 	c := make(chan watcherx.Event)
 	ctx, cancel := context.WithCancel(context.Background())
-	err := watcherx.WatchFile(ctx, os.Args[1], c)
+	_, err := watcherx.WatchFile(ctx, os.Args[1], c)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "could not initialize file watcher: %+v\n", err)
 		os.Exit(1)

--- a/watcherx/websocket_test.go
+++ b/watcherx/websocket_test.go
@@ -28,7 +28,9 @@ func TestWatchWebsocket(t *testing.T) {
 		f, err := os.Create(fn)
 		require.NoError(t, err)
 
-		handler, err := WatchAndServeWS(ctx, urlx.ParseOrPanic("file://"+fn), herodot.NewJSONWriter(l))
+		url, err := urlx.Parse("file://" + fn)
+		require.NoError(t, err)
+		handler, err := WatchAndServeWS(ctx, url, herodot.NewJSONWriter(l))
 		require.NoError(t, err)
 		s := httptest.NewServer(handler)
 


### PR DESCRIPTION
## Related issue

In many cases the data have to be retrieved when starting the watcher as well.
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

This adds a possibility to signal to the watcher that you need it to send the current value as if it changed into the current state.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->
