### PR TITLE
feat: logrusx pop logger and context in cmdx

### DIFF
--- a/logrusx/helper.go
+++ b/logrusx/helper.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/gobuffalo/pop/v5/logging"
+
 	"github.com/sirupsen/logrus"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
@@ -148,4 +150,17 @@ func (l *Logger) WithError(err error) *Logger {
 	}
 
 	return l.WithField("error", ctx)
+}
+
+var popLevelTranslations = map[logging.Level]logrus.Level{
+	logging.SQL:   logrus.TraceLevel,
+	logging.Debug: logrus.DebugLevel,
+	logging.Info:  logrus.InfoLevel,
+	logging.Warn:  logrus.WarnLevel,
+	logging.Error: logrus.ErrorLevel,
+}
+
+func (l *Logger) PopLogger(lvl logging.Level, s string, args ...interface{}) {
+	level := popLevelTranslations[lvl]
+	l.WithField("source", "pop").Logf(level, s, args...)
 }


### PR DESCRIPTION
The two commits are independent and should not be sqashed.

The pop logger allows us to have the pop logs in logrus using
```go
pop.SetLogger(l.PopLogger)
```

The command executor can be used to call a command multiple times with a given context and persistent arguments. E.g.

```go
			c := &cmdx.CommandExecuter{
				New: cmd.NewRootCmd,
				Ctx: ctx,
				PersistentArgs: []string{"--config", "path/to/test/config"},
			}
```