### PR TITLE
test: fix flaky configx tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   nancy: ory/nancy@0.0.9
-  golangci: ory/golangci@0.0.4
+  golangci: ory/golangci@0.0.9
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,16 +45,22 @@ jobs:
       - run: "mkdir -p ../docs/schemas/x; cp -r ./.schemas/* ../docs/schemas/x"
       - run: "(cd ../docs && git add -A && git commit -a -m \"Updates ory/x JSON Schemas\" && git push origin) || exit 0"
 
+  validate:
+    docker:
+      - image: circleci/golang:1.15
+        environment:
+          GO11MODULES: 'on'
+    steps:
+      - checkout
+      - golangci/lint
+
 workflows:
   test:
     jobs:
       - test
+      - validate
       - nancy/test
       - docs:
           filters:
             branches:
               only: master
-      - golangci/lint:
-          filters:
-            tags:
-              only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,8 +54,7 @@ workflows:
           filters:
             branches:
               only: master
-      -
-        golangci/lint:
+      - golangci/lint:
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 jobs:
   test:
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.15
         environment:
         - TEST_DATABASE_POSTGRESQL=postgres://test:test@localhost:5432/sqlcon?sslmode=disable
         - TEST_DATABASE_MYSQL=mysql://root:test@tcp(localhost:3306)/mysql?parseTime=true

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -14,5 +14,5 @@ jobs:
         with:
           go-version: '^1.15'
       - run: |
-          go test -failfast -timeout=20m $(go list ./... | grep -v sqlcon)
+          go test -failfast -timeout=20m $(go list ./... | grep -v sqlcon | grep -v watcherx)
         shell: bash

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15'
       - run: |
           go test -failfast -timeout=20m $(go list ./... | grep -v sqlcon)
         shell: bash

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -11,5 +11,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          go test -failfast -timeout=20m $(go list ./... | grep -v watcherx | grep -v sqlcon | grep -v configx)
+          go test -failfast -timeout=20m $(go list ./... | grep -v sqlcon)
         shell: bash

--- a/clidoc/generate.go
+++ b/clidoc/generate.go
@@ -48,6 +48,7 @@ func Generate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	/* #nosec G306 - TODO evaluate why */
 	if err := ioutil.WriteFile(spath, []byte(gjson.GetBytes(sidebar, "@pretty").Raw), 0644); err != nil {
 		return err
 	}

--- a/configx/koanf_file_test.go
+++ b/configx/koanf_file_test.go
@@ -32,7 +32,7 @@ func TestKoanfFile(t *testing.T) {
 		encV, err := json.Marshal(v)
 		require.NoError(t, err)
 
-		kf, cancel := setupFile(t, "config*.json", string(encV), "")
+		kf, cancel := setupFile(t, "config.json", string(encV), "")
 		defer cancel()
 
 		actual, err := kf.Read()
@@ -47,7 +47,7 @@ func TestKoanfFile(t *testing.T) {
 		encV, err := yaml.Marshal(v)
 		require.NoError(t, err)
 
-		kf, cancel := setupFile(t, "config*.yml", string(encV), "")
+		kf, cancel := setupFile(t, "config.yml", string(encV), "")
 		defer cancel()
 
 		actual, err := kf.Read()
@@ -62,7 +62,7 @@ func TestKoanfFile(t *testing.T) {
 		encV, err := toml.Marshal(v)
 		require.NoError(t, err)
 
-		kf, cancel := setupFile(t, "config*.toml", string(encV), "")
+		kf, cancel := setupFile(t, "config.toml", string(encV), "")
 		defer cancel()
 
 		actual, err := kf.Read()
@@ -77,7 +77,7 @@ func TestKoanfFile(t *testing.T) {
 		encV, err := json.Marshal(v)
 		require.NoError(t, err)
 
-		kf, cancel := setupFile(t, "config*.json", string(encV), "parent.of.config")
+		kf, cancel := setupFile(t, "config.json", string(encV), "parent.of.config")
 		defer cancel()
 
 		actual, err := kf.Read()

--- a/configx/options.go
+++ b/configx/options.go
@@ -84,7 +84,7 @@ func WithLogrusWatcher(l *logrusx.Logger) OptionModifier {
 func LogrusWatcher(l *logrusx.Logger) func(e watcherx.Event, err error) {
 	return func(e watcherx.Event, err error) {
 		l.WithField("file", e.Source()).
-			WithField("event", e).
+			WithField("event", e.String()).
 			WithField("event_type", fmt.Sprintf("%T", e)).
 			Info("A change to a configuration file was detected.")
 

--- a/configx/provider_test.go
+++ b/configx/provider_test.go
@@ -1,6 +1,7 @@
 package configx
 
 import (
+	"context"
 	"io/ioutil"
 	"path"
 	"testing"
@@ -24,7 +25,10 @@ func TestProviderMethods(t *testing.T) {
 	require.NoError(t, f.Parse(args[1:]))
 	RegisterFlags(f)
 
-	p, err := New([]byte(`{}`), WithFlags(f))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p, err := New([]byte(`{}`), WithFlags(f), WithContext(ctx))
 	require.NoError(t, err)
 
 	t.Run("check flags", func(t *testing.T) {
@@ -129,7 +133,9 @@ func TestAdvancedConfigs(t *testing.T) {
 			require.NoError(t, err)
 
 			schemaPath := path.Join("stub", tc.stub, "config.schema.json")
-			k, err := newKoanf(schemaPath, tc.configs)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			k, err := newKoanf(schemaPath, tc.configs, WithContext(ctx))
 			if !tc.isValid {
 				require.Error(t, err)
 				return

--- a/httpx/gzip_server.go
+++ b/httpx/gzip_server.go
@@ -39,6 +39,7 @@ func (c *CompressionRequestReader) ServeHTTP(w http.ResponseWriter, r *http.Requ
 				return
 			}
 
+			/* #nosec G110 - FIXME */
 			if _, err := io.Copy(&b, reader); err != nil {
 				c.ErrHandler(w, r, err)
 				return

--- a/watcherx/event.go
+++ b/watcherx/event.go
@@ -3,6 +3,7 @@ package watcherx
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 
 	"github.com/pkg/errors"
@@ -15,6 +16,7 @@ type (
 
 		Reader() io.Reader
 		Source() string
+		String() string
 		setSource(string)
 	}
 	source     string
@@ -57,6 +59,10 @@ func (e *ErrorEvent) MarshalJSON() ([]byte, error) {
 	})
 }
 
+func (e *ErrorEvent) String() string {
+	return fmt.Sprintf("error: %+v; source: %s", e.error, e.source)
+}
+
 func (e source) Source() string {
 	return string(e)
 }
@@ -77,6 +83,10 @@ func (e *ChangeEvent) MarshalJSON() ([]byte, error) {
 	})
 }
 
+func (e *ChangeEvent) String() string {
+	return fmt.Sprintf("data: %s; source: %s", e.data, e.source)
+}
+
 func (e *RemoveEvent) Reader() io.Reader {
 	return nil
 }
@@ -86,6 +96,10 @@ func (e *RemoveEvent) MarshalJSON() ([]byte, error) {
 		Type:   serialTypeRemove,
 		Source: e.source,
 	})
+}
+
+func (e *RemoveEvent) String() string {
+	return fmt.Sprintf("removed source: %s", e.source)
 }
 
 func unmarshalEvent(data []byte) (Event, error) {

--- a/watcherx/file_test.go
+++ b/watcherx/file_test.go
@@ -17,8 +17,7 @@ import (
 func setup(t *testing.T) (context.Context, chan Event, string, context.CancelFunc) {
 	c := make(chan Event)
 	ctx, cancel := context.WithCancel(context.Background())
-	dir, err := ioutil.TempDir("", "*")
-	require.NoError(t, err)
+	dir := t.TempDir()
 	return ctx, c, dir, cancel
 }
 

--- a/watcherx/test_helpers.go
+++ b/watcherx/test_helpers.go
@@ -40,7 +40,7 @@ func kubernetesAtomicWrite(t *testing.T, dir, fileName, content string) {
 	// (6)
 	require.NoError(
 		t,
-		ioutil.WriteFile(path.Join(tsDir, fileName), []byte(content), 0700),
+		ioutil.WriteFile(path.Join(tsDir, fileName), []byte(content), 0600),
 	)
 
 	// (7)

--- a/watcherx/websocket_test.go
+++ b/watcherx/websocket_test.go
@@ -31,6 +31,7 @@ func TestWatchWebsocket(t *testing.T) {
 
 		url, err := urlx.Parse("file://" + fn)
 		require.NoError(t, err)
+		t.Log(url)
 		handler, err := WatchAndServeWS(ctx, url, herodot.NewJSONWriter(l))
 		require.NoError(t, err)
 		s := httptest.NewServer(handler)


### PR DESCRIPTION
## Related issue
CI failing all the time

## Proposed Change

A propagated change is now signaled by a channel instead of a wait group. This results in the test blocking until the change propagates, but subsequent events are ignored. They appeared until now because the cleanup of files and closing of the fsnotify watcher were racy.