### PR TITLE
feat(cmdx): add conditional printer and noise convenience functions

### DIFF
--- a/cmdx/noise_printer.go
+++ b/cmdx/noise_printer.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-type conditionalPrinter struct {
+type ConditionalPrinter struct {
 	w     io.Writer
 	print bool
 }
@@ -21,112 +21,112 @@ func RegisterNoiseFlags(flags *pflag.FlagSet) {
 	flags.BoolP(FlagQuiet, FlagQuiet[:1], false, "Be quiet with output printing.")
 }
 
-// NewLoudOutPrinter returns a conditionalPrinter that
+// NewLoudOutPrinter returns a ConditionalPrinter that
 // only prints to cmd.OutOrStdout when --quiet is not set
-func NewLoudOutPrinter(cmd *cobra.Command) *conditionalPrinter {
+func NewLoudOutPrinter(cmd *cobra.Command) *ConditionalPrinter {
 	quiet, err := cmd.Flags().GetBool(FlagQuiet)
 	if err != nil {
 		Fatalf(err.Error())
 	}
 
-	return &conditionalPrinter{
+	return &ConditionalPrinter{
 		w:     cmd.OutOrStdout(),
 		print: !quiet,
 	}
 }
 
-// NewQuietOutPrinter returns a conditionalPrinter that
+// NewQuietOutPrinter returns a ConditionalPrinter that
 // only prints to cmd.OutOrStdout when --quiet is set
-func NewQuietOutPrinter(cmd *cobra.Command) *conditionalPrinter {
+func NewQuietOutPrinter(cmd *cobra.Command) *ConditionalPrinter {
 	quiet, err := cmd.Flags().GetBool(FlagQuiet)
 	if err != nil {
 		Fatalf(err.Error())
 	}
 
-	return &conditionalPrinter{
+	return &ConditionalPrinter{
 		w:     cmd.OutOrStdout(),
 		print: quiet,
 	}
 }
 
-// NewLoudErrPrinter returns a conditionalPrinter that
+// NewLoudErrPrinter returns a ConditionalPrinter that
 // only prints to cmd.ErrOrStderr when --quiet is not set
-func NewLoudErrPrinter(cmd *cobra.Command) *conditionalPrinter {
+func NewLoudErrPrinter(cmd *cobra.Command) *ConditionalPrinter {
 	quiet, err := cmd.Flags().GetBool(FlagQuiet)
 	if err != nil {
 		Fatalf(err.Error())
 	}
 
-	return &conditionalPrinter{
+	return &ConditionalPrinter{
 		w:     cmd.ErrOrStderr(),
 		print: !quiet,
 	}
 }
 
-// NewQuietErrPrinter returns a conditionalPrinter that
+// NewQuietErrPrinter returns a ConditionalPrinter that
 // only prints to cmd.ErrOrStderr when --quiet is set
-func NewQuietErrPrinter(cmd *cobra.Command) *conditionalPrinter {
+func NewQuietErrPrinter(cmd *cobra.Command) *ConditionalPrinter {
 	quiet, err := cmd.Flags().GetBool(FlagQuiet)
 	if err != nil {
 		Fatalf(err.Error())
 	}
 
-	return &conditionalPrinter{
+	return &ConditionalPrinter{
 		w:     cmd.ErrOrStderr(),
 		print: quiet,
 	}
 }
 
-// NewLoudPrinter returns a conditionalPrinter that
+// NewLoudPrinter returns a ConditionalPrinter that
 // only prints to w when --quiet is not set
-func NewLoudPrinter(cmd *cobra.Command, w io.Writer) *conditionalPrinter {
+func NewLoudPrinter(cmd *cobra.Command, w io.Writer) *ConditionalPrinter {
 	quiet, err := cmd.Flags().GetBool(FlagQuiet)
 	if err != nil {
 		Fatalf(err.Error())
 	}
 
-	return &conditionalPrinter{
+	return &ConditionalPrinter{
 		w:     w,
 		print: !quiet,
 	}
 }
 
-// NewQuietPrinter returns a conditionalPrinter that
+// NewQuietPrinter returns a ConditionalPrinter that
 // only prints to w when --quiet is set
-func NewQuietPrinter(cmd *cobra.Command, w io.Writer) *conditionalPrinter {
+func NewQuietPrinter(cmd *cobra.Command, w io.Writer) *ConditionalPrinter {
 	quiet, err := cmd.Flags().GetBool(FlagQuiet)
 	if err != nil {
 		Fatalf(err.Error())
 	}
 
-	return &conditionalPrinter{
+	return &ConditionalPrinter{
 		w:     w,
 		print: quiet,
 	}
 }
 
-func NewConditionalPrinter(w io.Writer, print bool) *conditionalPrinter {
-	return &conditionalPrinter{
+func NewConditionalPrinter(w io.Writer, print bool) *ConditionalPrinter {
+	return &ConditionalPrinter{
 		w:     w,
 		print: print,
 	}
 }
 
-func (p *conditionalPrinter) Println(a ...interface{}) (n int, err error) {
+func (p *ConditionalPrinter) Println(a ...interface{}) (n int, err error) {
 	if p.print {
 		return fmt.Fprintln(p.w, a...)
 	}
 	return
 }
 
-func (p *conditionalPrinter) Print(a ...interface{}) (n int, err error) {
+func (p *ConditionalPrinter) Print(a ...interface{}) (n int, err error) {
 	if p.print {
 		return fmt.Fprint(p.w, a...)
 	}
 	return
 }
 
-func (p *conditionalPrinter) Printf(format string, a ...interface{}) (n int, err error) {
+func (p *ConditionalPrinter) Printf(format string, a ...interface{}) (n int, err error) {
 	if p.print {
 		return fmt.Fprintf(p.w, format, a...)
 	}

--- a/cmdx/noise_printer.go
+++ b/cmdx/noise_printer.go
@@ -1,0 +1,134 @@
+package cmdx
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type conditionalPrinter struct {
+	w     io.Writer
+	print bool
+}
+
+const (
+	FlagQuiet = "quiet"
+)
+
+func RegisterNoiseFlags(flags *pflag.FlagSet) {
+	flags.BoolP(FlagQuiet, FlagQuiet[:1], false, "Be quiet with output printing.")
+}
+
+// NewLoudOutPrinter returns a conditionalPrinter that
+// only prints to cmd.OutOrStdout when --quiet is not set
+func NewLoudOutPrinter(cmd *cobra.Command) *conditionalPrinter {
+	quiet, err := cmd.Flags().GetBool(FlagQuiet)
+	if err != nil {
+		Fatalf(err.Error())
+	}
+
+	return &conditionalPrinter{
+		w:     cmd.OutOrStdout(),
+		print: !quiet,
+	}
+}
+
+// NewQuietOutPrinter returns a conditionalPrinter that
+// only prints to cmd.OutOrStdout when --quiet is set
+func NewQuietOutPrinter(cmd *cobra.Command) *conditionalPrinter {
+	quiet, err := cmd.Flags().GetBool(FlagQuiet)
+	if err != nil {
+		Fatalf(err.Error())
+	}
+
+	return &conditionalPrinter{
+		w:     cmd.OutOrStdout(),
+		print: quiet,
+	}
+}
+
+// NewLoudErrPrinter returns a conditionalPrinter that
+// only prints to cmd.ErrOrStderr when --quiet is not set
+func NewLoudErrPrinter(cmd *cobra.Command) *conditionalPrinter {
+	quiet, err := cmd.Flags().GetBool(FlagQuiet)
+	if err != nil {
+		Fatalf(err.Error())
+	}
+
+	return &conditionalPrinter{
+		w:     cmd.ErrOrStderr(),
+		print: !quiet,
+	}
+}
+
+// NewQuietErrPrinter returns a conditionalPrinter that
+// only prints to cmd.ErrOrStderr when --quiet is set
+func NewQuietErrPrinter(cmd *cobra.Command) *conditionalPrinter {
+	quiet, err := cmd.Flags().GetBool(FlagQuiet)
+	if err != nil {
+		Fatalf(err.Error())
+	}
+
+	return &conditionalPrinter{
+		w:     cmd.ErrOrStderr(),
+		print: quiet,
+	}
+}
+
+// NewLoudPrinter returns a conditionalPrinter that
+// only prints to w when --quiet is not set
+func NewLoudPrinter(cmd *cobra.Command, w io.Writer) *conditionalPrinter {
+	quiet, err := cmd.Flags().GetBool(FlagQuiet)
+	if err != nil {
+		Fatalf(err.Error())
+	}
+
+	return &conditionalPrinter{
+		w:     w,
+		print: !quiet,
+	}
+}
+
+// NewQuietPrinter returns a conditionalPrinter that
+// only prints to w when --quiet is set
+func NewQuietPrinter(cmd *cobra.Command, w io.Writer) *conditionalPrinter {
+	quiet, err := cmd.Flags().GetBool(FlagQuiet)
+	if err != nil {
+		Fatalf(err.Error())
+	}
+
+	return &conditionalPrinter{
+		w:     w,
+		print: quiet,
+	}
+}
+
+func NewConditionalPrinter(w io.Writer, print bool) *conditionalPrinter {
+	return &conditionalPrinter{
+		w:     w,
+		print: print,
+	}
+}
+
+func (p *conditionalPrinter) Println(a ...interface{}) (n int, err error) {
+	if p.print {
+		return fmt.Fprintln(p.w, a...)
+	}
+	return
+}
+
+func (p *conditionalPrinter) Print(a ...interface{}) (n int, err error) {
+	if p.print {
+		return fmt.Fprint(p.w, a...)
+	}
+	return
+}
+
+func (p *conditionalPrinter) Printf(format string, a ...interface{}) (n int, err error) {
+	if p.print {
+		return fmt.Fprintf(p.w, format, a...)
+	}
+	return
+}

--- a/cmdx/noise_printer_test.go
+++ b/cmdx/noise_printer_test.go
@@ -1,0 +1,79 @@
+package cmdx
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConditionalPrinter(t *testing.T) {
+	const (
+		msgAlwaysOut = "always out"
+		msgAlwaysErr = "always err"
+		msgQuietOut  = "quiet out"
+		msgQuietErr  = "quiet err"
+		msgLoudOut   = "loud out"
+		msgLoudErr   = "loud err"
+		msgArgsSet   = "args were set"
+	)
+	setup := func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "test cmd",
+			Run: func(cmd *cobra.Command, args []string) {
+				_, _ = fmt.Fprint(cmd.OutOrStdout(), msgAlwaysOut)
+				_, _ = fmt.Fprint(cmd.ErrOrStderr(), msgAlwaysErr)
+				_, _ = NewQuietOutPrinter(cmd).Print(msgQuietOut)
+				_, _ = NewQuietErrPrinter(cmd).Print(msgQuietErr)
+				_, _ = NewLoudOutPrinter(cmd).Print(msgLoudOut)
+				_, _ = NewLoudErrPrinter(cmd).Print(msgLoudErr)
+				_, _ = NewConditionalPrinter(cmd.OutOrStdout(), len(args) > 0).Print(msgArgsSet)
+			},
+		}
+		RegisterNoiseFlags(cmd.Flags())
+		return cmd
+	}
+
+	for _, tc := range []struct {
+		stdErrMsg, stdOutMsg, args []string
+		setQuiet                   bool
+	}{
+		{
+			stdOutMsg: []string{msgLoudOut},
+			stdErrMsg: []string{msgLoudErr},
+			setQuiet:  false,
+			args:      []string{},
+		},
+		{
+			stdOutMsg: []string{msgQuietOut},
+			stdErrMsg: []string{msgQuietErr},
+			setQuiet:  true,
+			args:      []string{},
+		},
+		{
+			stdOutMsg: []string{msgQuietOut, msgArgsSet},
+			stdErrMsg: []string{msgQuietErr},
+			setQuiet:  true,
+			args:      []string{"foo"},
+		},
+	} {
+		t.Run(fmt.Sprintf("case=quiet:%v", tc.setQuiet), func(t *testing.T) {
+			cmd := setup()
+			if tc.setQuiet {
+				require.NoError(t, cmd.Flags().Set(FlagQuiet, "true"))
+			}
+			out, err := &bytes.Buffer{}, &bytes.Buffer{}
+			cmd.SetOut(out)
+			cmd.SetErr(err)
+			cmd.SetArgs(tc.args)
+
+			require.NoError(t, cmd.Execute())
+			assert.Equal(t, strings.Join(append([]string{msgAlwaysOut}, tc.stdOutMsg...), ""), out.String())
+			assert.Equal(t, strings.Join(append([]string{msgAlwaysErr}, tc.stdErrMsg...), ""), err.String())
+		})
+	}
+}

--- a/cmdx/printing.go
+++ b/cmdx/printing.go
@@ -37,7 +37,6 @@ const (
 	FormatJSONPretty format = "json-pretty"
 	FormatDefault    format = "default"
 
-	FlagQuiet  = "quiet"
 	FlagFormat = "format"
 
 	None = "<none>"
@@ -169,6 +168,6 @@ func RegisterJSONFormatFlags(flags *pflag.FlagSet) {
 }
 
 func RegisterFormatFlags(flags *pflag.FlagSet) {
-	flags.BoolP(FlagQuiet, FlagQuiet[:1], false, "Prints only IDs, one per line. Takes precedence over --format.")
+	RegisterNoiseFlags(flags)
 	flags.StringP(FlagFormat, FlagFormat[:1], "", fmt.Sprintf("Set the output format. One of %s, %s, and %s.", FormatTable, FormatJSON, FormatJSONPretty))
 }


### PR DESCRIPTION

## Proposed changes

This allows us to write better readable code in commands that print. E.g.:

```go
if !flagx.MustGetBool(cmd, FlagQuiet) {
	fmt.Fprintf(cmd.ErrOrStderr(), "Increasing memory to get over %s:\n", desiredDuration)
}
```
becomes
```go
loudPrinter := cmdx.NewLoudOutPrinter(cmd)
loudPrinter.Printf("Increasing memory to get over %s:\n", desiredDuration)
```
