### PR TITLE
fix(cmdx): table printing default should be table

### DIFF
--- a/cmdx/printing.go
+++ b/cmdx/printing.go
@@ -58,7 +58,7 @@ func PrintRow(cmd *cobra.Command, row TableRow) {
 		printJSON(cmd.OutOrStdout(), row.Interface(), false)
 	case FormatJSONPretty:
 		printJSON(cmd.OutOrStdout(), row.Interface(), true)
-	case FormatTable:
+	case FormatTable, FormatDefault:
 		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 8, 1, '\t', 0)
 
 		fields := row.Columns()
@@ -164,10 +164,10 @@ func printJSON(w io.Writer, v interface{}, pretty bool) {
 }
 
 func RegisterJSONFormatFlags(flags *pflag.FlagSet) {
-	flags.StringP(FlagFormat, FlagFormat[:1], "", fmt.Sprintf("Set the output format. One of %s, %s, and %s.", FormatDefault, FormatJSON, FormatJSONPretty))
+	flags.StringP(FlagFormat, FlagFormat[:1], string(FormatDefault), fmt.Sprintf("Set the output format. One of %s, %s, and %s.", FormatDefault, FormatJSON, FormatJSONPretty))
 }
 
 func RegisterFormatFlags(flags *pflag.FlagSet) {
 	RegisterNoiseFlags(flags)
-	flags.StringP(FlagFormat, FlagFormat[:1], "", fmt.Sprintf("Set the output format. One of %s, %s, and %s.", FormatTable, FormatJSON, FormatJSONPretty))
+	flags.StringP(FlagFormat, FlagFormat[:1], string(FormatDefault), fmt.Sprintf("Set the output format. One of %s, %s, and %s.", FormatTable, FormatJSON, FormatJSONPretty))
 }

--- a/cmdx/printing_test.go
+++ b/cmdx/printing_test.go
@@ -1,0 +1,27 @@
+package cmdx
+
+import (
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestRegisterFlags(t *testing.T) {
+	setup := func() *pflag.FlagSet {
+		flags := pflag.NewFlagSet("test flags", pflag.ContinueOnError)
+		RegisterFormatFlags(flags)
+		return flags
+	}
+
+	t.Run("case=format flags", func(t *testing.T) {
+		t.Run("format=no value", func(t *testing.T) {
+			flags := setup()
+			require.NoError(t, flags.Parse([]string{}))
+			f, err := flags.GetString(FlagFormat)
+			require.NoError(t, err)
+
+			assert.Equal(t, FormatDefault, format(f))
+		})
+	})
+}

--- a/cmdx/printing_test.go
+++ b/cmdx/printing_test.go
@@ -1,10 +1,11 @@
 package cmdx
 
 import (
+	"testing"
+
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestRegisterFlags(t *testing.T) {


### PR DESCRIPTION
## Related issue

With #257 the default format for a table printer was changed by mistake to no output.