### PR TITLE
chore: use interfaces instead of testing types

### DIFF
--- a/cmdx/helper.go
+++ b/cmdx/helper.go
@@ -102,14 +102,14 @@ func ExpectDependency(logger *logrusx.Logger, dependencies ...interface{}) {
 
 // Exec runs the provided cobra command with the given reader as STD_IN and the given args.
 // Returns STD_OUT, STD_ERR and the error from the execution.
-func Exec(t *testing.T, cmd *cobra.Command, stdIn io.Reader, args ...string) (string, string, error) {
+func Exec(t testing.TB, cmd *cobra.Command, stdIn io.Reader, args ...string) (string, string, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
 	return ExecCtx(ctx, t, cmd, stdIn, args...)
 }
 
-func ExecCtx(ctx context.Context, _ *testing.T, cmd *cobra.Command, stdIn io.Reader, args ...string) (string, string, error) {
+func ExecCtx(ctx context.Context, _ require.TestingT, cmd *cobra.Command, stdIn io.Reader, args ...string) (string, string, error) {
 	stdOut, stdErr := &bytes.Buffer{}, &bytes.Buffer{}
 	cmd.SetErr(stdErr)
 	cmd.SetOut(stdOut)
@@ -125,14 +125,14 @@ func ExecCtx(ctx context.Context, _ *testing.T, cmd *cobra.Command, stdIn io.Rea
 
 // ExecNoErr is a helper that assumes a successful run from Exec.
 // Returns STD_OUT.
-func ExecNoErr(t *testing.T, cmd *cobra.Command, args ...string) string {
+func ExecNoErr(t testing.TB, cmd *cobra.Command, args ...string) string {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
 	return ExecNoErrCtx(ctx, t, cmd, args...)
 }
 
-func ExecNoErrCtx(ctx context.Context, t *testing.T, cmd *cobra.Command, args ...string) string {
+func ExecNoErrCtx(ctx context.Context, t require.TestingT, cmd *cobra.Command, args ...string) string {
 	stdOut, stdErr, err := ExecCtx(ctx, t, cmd, nil, args...)
 	require.NoError(t, err, "std_out: %s\nstd_err: %s", stdOut, stdErr)
 	require.Len(t, stdErr, 0, stdOut)
@@ -141,15 +141,15 @@ func ExecNoErrCtx(ctx context.Context, t *testing.T, cmd *cobra.Command, args ..
 
 // ExecExpectedErr is a helper that assumes a failing run from Exec returning ErrNoPrintButFail
 // Returns STD_ERR.
-func ExecExpectedErr(t *testing.T, cmd *cobra.Command, args ...string) string {
+func ExecExpectedErr(t testing.TB, cmd *cobra.Command, args ...string) string {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
 	return ExecExpectedErrCtx(ctx, t, cmd, args...)
 }
 
-func ExecExpectedErrCtx(_ context.Context, t *testing.T, cmd *cobra.Command, args ...string) string {
-	stdOut, stdErr, err := Exec(t, cmd, nil, args...)
+func ExecExpectedErrCtx(ctx context.Context, t require.TestingT, cmd *cobra.Command, args ...string) string {
+	stdOut, stdErr, err := ExecCtx(ctx, t, cmd, nil, args...)
 	require.True(t, errors.Is(err, ErrNoPrintButFail), "std_out: %s\nstd_err: %s", stdOut, stdErr)
 	require.Len(t, stdOut, 0, stdErr)
 	return stdErr
@@ -161,14 +161,14 @@ type CommandExecuter struct {
 	PersistentArgs []string
 }
 
-func (c *CommandExecuter) Exec(t *testing.T, stdin io.Reader, args ...string) (string, string, error) {
+func (c *CommandExecuter) Exec(t require.TestingT, stdin io.Reader, args ...string) (string, string, error) {
 	return ExecCtx(c.Ctx, t, c.New(), stdin, append(c.PersistentArgs, args...)...)
 }
 
-func (c *CommandExecuter) ExecNoErr(t *testing.T, args ...string) string {
+func (c *CommandExecuter) ExecNoErr(t require.TestingT, args ...string) string {
 	return ExecNoErrCtx(c.Ctx, t, c.New(), append(c.PersistentArgs, args...)...)
 }
 
-func (c *CommandExecuter) ExecExpectedErr(t *testing.T, args ...string) string {
+func (c *CommandExecuter) ExecExpectedErr(t require.TestingT, args ...string) string {
 	return ExecExpectedErrCtx(c.Ctx, t, c.New(), append(c.PersistentArgs, args...)...)
 }

--- a/cmdx/helper.go
+++ b/cmdx/helper.go
@@ -106,10 +106,10 @@ func Exec(t testing.TB, cmd *cobra.Command, stdIn io.Reader, args ...string) (st
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	return ExecCtx(ctx, t, cmd, stdIn, args...)
+	return ExecCtx(ctx, cmd, stdIn, args...)
 }
 
-func ExecCtx(ctx context.Context, _ require.TestingT, cmd *cobra.Command, stdIn io.Reader, args ...string) (string, string, error) {
+func ExecCtx(ctx context.Context, cmd *cobra.Command, stdIn io.Reader, args ...string) (string, string, error) {
 	stdOut, stdErr := &bytes.Buffer{}, &bytes.Buffer{}
 	cmd.SetErr(stdErr)
 	cmd.SetOut(stdOut)
@@ -133,7 +133,7 @@ func ExecNoErr(t testing.TB, cmd *cobra.Command, args ...string) string {
 }
 
 func ExecNoErrCtx(ctx context.Context, t require.TestingT, cmd *cobra.Command, args ...string) string {
-	stdOut, stdErr, err := ExecCtx(ctx, t, cmd, nil, args...)
+	stdOut, stdErr, err := ExecCtx(ctx, cmd, nil, args...)
 	require.NoError(t, err, "std_out: %s\nstd_err: %s", stdOut, stdErr)
 	require.Len(t, stdErr, 0, stdOut)
 	return stdOut
@@ -149,7 +149,7 @@ func ExecExpectedErr(t testing.TB, cmd *cobra.Command, args ...string) string {
 }
 
 func ExecExpectedErrCtx(ctx context.Context, t require.TestingT, cmd *cobra.Command, args ...string) string {
-	stdOut, stdErr, err := ExecCtx(ctx, t, cmd, nil, args...)
+	stdOut, stdErr, err := ExecCtx(ctx, cmd, nil, args...)
 	require.True(t, errors.Is(err, ErrNoPrintButFail), "std_out: %s\nstd_err: %s", stdOut, stdErr)
 	require.Len(t, stdOut, 0, stdErr)
 	return stdErr
@@ -161,8 +161,8 @@ type CommandExecuter struct {
 	PersistentArgs []string
 }
 
-func (c *CommandExecuter) Exec(t require.TestingT, stdin io.Reader, args ...string) (string, string, error) {
-	return ExecCtx(c.Ctx, t, c.New(), stdin, append(c.PersistentArgs, args...)...)
+func (c *CommandExecuter) Exec(stdin io.Reader, args ...string) (string, string, error) {
+	return ExecCtx(c.Ctx, c.New(), stdin, append(c.PersistentArgs, args...)...)
 }
 
 func (c *CommandExecuter) ExecNoErr(t require.TestingT, args ...string) string {

--- a/sqlcon/dockertest/test_helper.go
+++ b/sqlcon/dockertest/test_helper.go
@@ -102,7 +102,7 @@ func connect(dialect, driver, dsn string) (db *sqlx.DB, err error) {
 	return db, nil
 }
 
-func connectPop(t *testing.T, url string) (c *pop.Connection) {
+func connectPop(t require.TestingT, url string) (c *pop.Connection) {
 	require.NoError(t, resilience.Retry(logrusx.New("", ""), time.Second*5, time.Minute*5, func() error {
 		var err error
 		c, err = pop.NewConnection(&pop.ConnectionDetails{
@@ -138,7 +138,7 @@ func startPostgreSQL() (*dockertest.Resource, error) {
 }
 
 // RunTestPostgreSQL runs a PostgreSQL database and returns the URL to it.
-func RunTestPostgreSQL(t *testing.T) string {
+func RunTestPostgreSQL(t testing.TB) string {
 	if dsn := os.Getenv("TEST_DATABASE_POSTGRESQL"); dsn != "" {
 		t.Logf("Skipping Docker setup because environment variable TEST_DATABASE_POSTGRESQL is set to: %s", dsn)
 		return dsn
@@ -175,7 +175,7 @@ func ConnectToTestPostgreSQL() (*sqlx.DB, error) {
 	return db, nil
 }
 
-func ConnectToTestPostgreSQLPop(t *testing.T) *pop.Connection {
+func ConnectToTestPostgreSQLPop(t testing.TB) *pop.Connection {
 	url := RunTestPostgreSQL(t)
 	return connectPop(t, url)
 }
@@ -206,7 +206,7 @@ func RunMySQL() (string, error) {
 }
 
 // RunTestMySQL runs a MySQL database and returns the URL to it.
-func RunTestMySQL(t *testing.T) string {
+func RunTestMySQL(t testing.TB) string {
 	if dsn := os.Getenv("TEST_DATABASE_MYSQL"); dsn != "" {
 		t.Logf("Skipping Docker setup because environment variable TEST_DATABASE_MYSQL is set to: %s", dsn)
 		return dsn
@@ -234,7 +234,7 @@ func ConnectToTestMySQL() (*sqlx.DB, error) {
 	return db, nil
 }
 
-func ConnectToTestMySQLPop(t *testing.T) *pop.Connection {
+func ConnectToTestMySQLPop(t testing.TB) *pop.Connection {
 	url := RunTestMySQL(t)
 	return connectPop(t, url)
 }
@@ -269,7 +269,7 @@ func RunCockroachDB() (string, error) {
 }
 
 // RunTestCockroachDB runs a CockroachDB database and returns the URL to it.
-func RunTestCockroachDB(t *testing.T) string {
+func RunTestCockroachDB(t testing.TB) string {
 	if dsn := os.Getenv("TEST_DATABASE_COCKROACHDB"); dsn != "" {
 		t.Logf("Skipping Docker setup because environment variable TEST_DATABASE_COCKROACHDB is set to: %s", dsn)
 		return dsn
@@ -297,7 +297,7 @@ func ConnectToTestCockroachDB() (*sqlx.DB, error) {
 	return db, nil
 }
 
-func ConnectToTestCockroachDBPop(t *testing.T) *pop.Connection {
+func ConnectToTestCockroachDBPop(t testing.TB) *pop.Connection {
 	url := RunTestCockroachDB(t)
 	return connectPop(t, url)
 }


### PR DESCRIPTION
## Proposed changes

Using `testing.TB` allows to pass either `*testing.T` or `*testing.B`. Using `require.TestingT` will even allow wrapping the original testing struct to allow e.g. concurrent `FailNow()`. We should use the least restricting type possible from now on.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->
