### PR TITLE
fix(clidoc): sidebar spam

### DIFF
--- a/clidoc/generate.go
+++ b/clidoc/generate.go
@@ -16,6 +16,8 @@ import (
 	"github.com/tidwall/sjson"
 )
 
+const sideBarLabel = "Command Line Interface (CLI)"
+
 // Generate generates markdown documentation for a cobra command and its children.
 func Generate(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
@@ -40,14 +42,14 @@ func Generate(cmd *cobra.Command, args []string) error {
 
 	var index int
 	gjson.GetBytes(sidebar, `Reference`).ForEach(func(key, value gjson.Result) bool {
-		if strings.Contains(value.Get("label").String(), "CLI") {
+		if strings.Contains(value.Raw, sideBarLabel) {
 			return false
 		}
 		index++
 		return true
 	})
 
-	sidebar, err = sjson.SetBytes(sidebar, fmt.Sprintf(`Reference.%d.items`, index), navItems)
+	sidebar, err = sjson.SetBytes(sidebar, fmt.Sprintf(`Reference.%d.%s`, index, sideBarLabel), navItems)
 	if err != nil {
 		return err
 	}

--- a/clidoc/generate.go
+++ b/clidoc/generate.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -109,7 +110,7 @@ To improve this file please make your change against the appropriate "./cmd/*.go
 		return err
 	}
 
-	*navItems = append(*navItems, filepath.Join("cli", basename))
+	*navItems = append(*navItems, path.Join("cli", basename))
 	if err := doc.GenMarkdownCustom(cmd, f, trimExt); err != nil {
 		return err
 	}

--- a/clidoc/generate_test.go
+++ b/clidoc/generate_test.go
@@ -1,0 +1,75 @@
+package clidoc
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func noopRun(_ *cobra.Command, _ []string) {}
+
+var (
+	root      = &cobra.Command{Use: "root", Run: noopRun}
+	child1    = &cobra.Command{Use: "child1", Run: noopRun}
+	child2    = &cobra.Command{Use: "child2", Run: noopRun}
+	subChild1 = &cobra.Command{Use: "subChild1", Run: noopRun}
+)
+
+func snapshotDir(t *testing.T, path ...string) (assertNoChange func(t *testing.T)) {
+	var (
+		as  []func(*testing.T)
+		fps []string
+	)
+
+	require.NoError(t, filepath.WalkDir(filepath.Join(path...), func(path string, d fs.DirEntry, err error) error {
+		require.NoError(t, err, path)
+		if !d.IsDir() {
+			fps = append(fps, path)
+			as = append(as, snapshotFile(t, path))
+		}
+		return nil
+	}))
+
+	return func(t *testing.T) {
+		fileN := 0
+		require.NoError(t, filepath.WalkDir(filepath.Join(path...), func(path string, d fs.DirEntry, err error) error {
+			require.NoError(t, err)
+			if !d.IsDir() {
+				assert.Contains(t, fps, path)
+				fileN++
+			}
+			return nil
+		}))
+		assert.Equal(t, len(fps), fileN)
+
+		for _, a := range as {
+			a(t)
+		}
+	}
+}
+
+func snapshotFile(t *testing.T, path ...string) (assertNoChange func(t *testing.T)) {
+	pre, err := os.ReadFile(filepath.Join(path...))
+	require.NoError(t, err)
+
+	return func(t *testing.T) {
+		post, err := os.ReadFile(filepath.Join(path...))
+		require.NoError(t, err)
+
+		assert.Equal(t, string(pre), string(post))
+	}
+}
+
+func TestGenerate(t *testing.T) {
+	child1.AddCommand(subChild1)
+	root.AddCommand(child1, child2)
+
+	assertNoChange := snapshotDir(t, "testdata")
+	require.NoError(t, Generate(root, []string{"testdata"}))
+	assertNoChange(t)
+}

--- a/clidoc/generate_test.go
+++ b/clidoc/generate_test.go
@@ -1,6 +1,7 @@
 package clidoc
 
 import (
+	"bytes"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -56,6 +57,7 @@ func snapshotDir(t *testing.T, path ...string) (assertNoChange func(t *testing.T
 func snapshotFile(t *testing.T, path ...string) (assertNoChange func(t *testing.T)) {
 	pre, err := os.ReadFile(filepath.Join(path...))
 	require.NoError(t, err)
+	pre = bytes.ReplaceAll(pre, []byte("\r\n"), []byte("\n"))
 
 	return func(t *testing.T) {
 		post, err := os.ReadFile(filepath.Join(path...))

--- a/clidoc/testdata/docs/docs/cli/root-child1-subChild1.md
+++ b/clidoc/testdata/docs/docs/cli/root-child1-subChild1.md
@@ -1,0 +1,33 @@
+---
+id: root-child1-subChild1
+title: root child1 subChild1
+description: root child1 subChild1 
+---
+
+<!--
+This file is auto-generated.
+
+To improve this file please make your change against the appropriate "./cmd/*.go" file.
+-->
+## root child1 subChild1
+
+
+
+### Synopsis
+
+
+
+```
+root child1 subChild1 [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for subChild1
+```
+
+### SEE ALSO
+
+* [root child1](root-child1)	 - 
+

--- a/clidoc/testdata/docs/docs/cli/root-child1.md
+++ b/clidoc/testdata/docs/docs/cli/root-child1.md
@@ -1,0 +1,34 @@
+---
+id: root-child1
+title: root child1
+description: root child1 
+---
+
+<!--
+This file is auto-generated.
+
+To improve this file please make your change against the appropriate "./cmd/*.go" file.
+-->
+## root child1
+
+
+
+### Synopsis
+
+
+
+```
+root child1 [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for child1
+```
+
+### SEE ALSO
+
+* [root](root)	 - 
+* [root child1 subChild1](root-child1-subChild1)	 - 
+

--- a/clidoc/testdata/docs/docs/cli/root-child2.md
+++ b/clidoc/testdata/docs/docs/cli/root-child2.md
@@ -1,0 +1,33 @@
+---
+id: root-child2
+title: root child2
+description: root child2 
+---
+
+<!--
+This file is auto-generated.
+
+To improve this file please make your change against the appropriate "./cmd/*.go" file.
+-->
+## root child2
+
+
+
+### Synopsis
+
+
+
+```
+root child2 [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for child2
+```
+
+### SEE ALSO
+
+* [root](root)	 - 
+

--- a/clidoc/testdata/docs/docs/cli/root.md
+++ b/clidoc/testdata/docs/docs/cli/root.md
@@ -1,0 +1,34 @@
+---
+id: root
+title: root
+description: root 
+---
+
+<!--
+This file is auto-generated.
+
+To improve this file please make your change against the appropriate "./cmd/*.go" file.
+-->
+## root
+
+
+
+### Synopsis
+
+
+
+```
+root [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for root
+```
+
+### SEE ALSO
+
+* [root child1](root-child1)	 - 
+* [root child2](root-child2)	 - 
+

--- a/clidoc/testdata/docs/sidebar.json
+++ b/clidoc/testdata/docs/sidebar.json
@@ -1,0 +1,18 @@
+{
+  "Introduction": ["index", "install", "performance", "quickstart"],
+  "Concepts": ["concepts/relation-tuples", "concepts/graph-of-relations"],
+  "Examples": ["examples/olymp-file-sharing"],
+  "Reference": [
+    "reference/configuration", 
+    "reference/proto-api", 
+    {
+      "Command Line Interface (CLI)": [
+        "cli/root", 
+        "cli/root-child1", 
+        "cli/root-child1-subChild1", 
+        "cli/root-child2"
+      ]
+    }
+  ],
+  "Development": ["milestones"]
+}


### PR DESCRIPTION
Regression of the sidebar spam bug. Looks like this was caused because of a change to the sidebar file format. Added a snapshot test.