### PR TITLE
chore: update repository template to c7a2e1f9

### DIFF
--- a/.github/CODEOWNER
+++ b/.github/CODEOWNER
@@ -1,0 +1,1 @@
+*       @ory/maintainers


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/c7a2e1f9ac8e52f80278670c47aa6a562872ebc5.