### PR TITLE
feat(decoderx): explicit request query checking

### DIFF
--- a/decoderx/http.go
+++ b/decoderx/http.go
@@ -39,6 +39,7 @@ type (
 		maxCircularReferenceDepth uint8
 		handleParseErrors         parseErrorStrategy
 		expectJSONFlattened       bool
+		queryAndBody              bool
 	}
 
 	// HTTPDecoderOption configures the HTTP decoder.
@@ -122,6 +123,14 @@ func HTTPDecoderJSONFollowsFormFormat() HTTPDecoderOption {
 func HTTPDecoderAllowedMethods(method ...string) HTTPDecoderOption {
 	return func(o *httpDecoderOptions) {
 		o.allowedHTTPMethods = method
+	}
+}
+
+// HTTPDecoderUseQueryAndBody will check both the HTTP body and the HTTP query params when decoding.
+// Only relevant for non-GET operations.
+func HTTPDecoderUseQueryAndBody() HTTPDecoderOption {
+	return func(o *httpDecoderOptions) {
+		o.queryAndBody = true
 	}
 }
 
@@ -363,7 +372,7 @@ func (t *HTTP) decodeForm(r *http.Request, destination interface{}, o *httpDecod
 	}
 
 	values := r.PostForm
-	if r.Method == "GET" {
+	if r.Method == "GET" || o.queryAndBody {
 		values = r.Form
 	}
 

--- a/decoderx/http_test.go
+++ b/decoderx/http_test.go
@@ -146,6 +146,52 @@ func TestHTTPFormDecoder(t *testing.T) {
 }`,
 		},
 		{
+			d: "should pass form request with payload in query and type assert data",
+			request: newRequest(t, "POST", "/?age=29", bytes.NewBufferString(url.Values{
+				"name.first": {"Aeneas"},
+				"name.last":  {"Rekkas"},
+				"ratio":      {"0.9"},
+				"consent":    {"true"},
+				// newsletter represents a special case for checkbox input with true/false and raw HTML.
+				"newsletter": {
+					"false", // comes from <input type="hidden" name="newsletter" value="false">
+					"true",  // comes from <input type="checkbox" name="newsletter" value="true" checked>
+				},
+			}.Encode()), httpContentTypeURLEncodedForm),
+			options: []HTTPDecoderOption{HTTPJSONSchemaCompiler("stub/person.json", nil)},
+			expected: `{
+	"name": {"first": "Aeneas", "last": "Rekkas"},
+	"newsletter": true,
+	"consent": true,
+	"ratio": 0.9
+}`,
+		},
+		{
+			d: "should pass form request with payload in query and type assert data",
+			request: newRequest(t, "POST", "/?age=29", bytes.NewBufferString(url.Values{
+				"name.first": {"Aeneas"},
+				"name.last":  {"Rekkas"},
+				"ratio":      {"0.9"},
+				"consent":    {"true"},
+				// newsletter represents a special case for checkbox input with true/false and raw HTML.
+				"newsletter": {
+					"false", // comes from <input type="hidden" name="newsletter" value="false">
+					"true",  // comes from <input type="checkbox" name="newsletter" value="true" checked>
+				},
+			}.Encode()), httpContentTypeURLEncodedForm),
+			options: []HTTPDecoderOption{
+				HTTPDecoderUseQueryAndBody(),
+				HTTPJSONSchemaCompiler("stub/person.json", nil),
+			},
+			expected: `{
+	"name": {"first": "Aeneas", "last": "Rekkas"},
+	"age": 29,
+	"newsletter": true,
+	"consent": true,
+	"ratio": 0.9
+}`,
+		},
+		{
 			d:             "should fail json request formatted as form if payload is invalid",
 			request:       newRequest(t, "POST", "/", bytes.NewBufferString(`{"name.first":"Aeneas", "name.last":"Rekkas","age":"not-a-number"}`), httpContentTypeJSON),
 			options:       []HTTPDecoderOption{HTTPJSONSchemaCompiler("stub/person.json", nil)},


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
