### PR TITLE
feat(decoderx): support query params in json payloads as well

### DIFF
--- a/decoderx/http.go
+++ b/decoderx/http.go
@@ -332,6 +332,13 @@ func (t *HTTP) decodeJSONForm(r *http.Request, destination interface{}, o *httpD
 		return true
 	})
 
+	if o.queryAndBody {
+		_ = r.ParseForm()
+		for k := range r.Form {
+			values.Set(k, r.Form.Get(k))
+		}
+	}
+
 	raw, err := t.decodeURLValues(values, paths, o)
 	if err != nil {
 		return err

--- a/decoderx/http_test.go
+++ b/decoderx/http_test.go
@@ -218,6 +218,45 @@ func TestHTTPFormDecoder(t *testing.T) {
 }`,
 		},
 		{
+			d: "should pass JSON request formatted as a form",
+			request: newRequest(t, "POST", "/?age=29", bytes.NewBufferString(`{
+	"name.first": "Aeneas",
+	"name.last":  "Rekkas",
+	"ratio":      0.9,
+	"consent":    false,
+	"newsletter": true
+}`), httpContentTypeJSON),
+			options: []HTTPDecoderOption{HTTPDecoderJSONFollowsFormFormat(),
+				HTTPJSONSchemaCompiler("stub/person.json", nil)},
+			expected: `{
+	"name": {"first": "Aeneas", "last": "Rekkas"},
+	"newsletter": true,
+	"consent": false,
+	"ratio": 0.9
+}`,
+		},
+		{
+			d: "should pass JSON request formatted as a form",
+			request: newRequest(t, "POST", "/?age=29", bytes.NewBufferString(`{
+	"name.first": "Aeneas",
+	"name.last":  "Rekkas",
+	"ratio":      0.9,
+	"consent":    false,
+	"newsletter": true
+}`), httpContentTypeJSON),
+			options: []HTTPDecoderOption{
+				HTTPDecoderUseQueryAndBody(),
+				HTTPDecoderJSONFollowsFormFormat(),
+				HTTPJSONSchemaCompiler("stub/person.json", nil)},
+			expected: `{
+	"name": {"first": "Aeneas", "last": "Rekkas"},
+	"age": 29,
+	"newsletter": true,
+	"consent": false,
+	"ratio": 0.9
+}`,
+		},
+		{
 			d: "should pass JSON request GET request",
 			request: newRequest(t, "GET", "/?"+url.Values{
 				"name.first": {"Aeneas"},


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
