### PR TITLE
refactor: move hydra unix sockets support helpers into ory/x

### DIFF
--- a/configx/helpers.go
+++ b/configx/helpers.go
@@ -1,10 +1,21 @@
 package configx
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/spf13/pflag"
 )
 
 // RegisterFlags registers the config file flag.
 func RegisterFlags(flags *pflag.FlagSet) {
 	flags.StringSliceP("config", "c", []string{}, "Path to one or more .json, .yaml, .yml, .toml config files. Values are loaded in the order provided, meaning that the last config file overwrites values from the previous config file.")
+}
+
+// host = unix:/path/to/socket => port is discarded, otherwise format as host:port
+func GetAddress(host string, port int) string {
+	if strings.HasPrefix(host, "unix:") {
+		return host
+	}
+	return fmt.Sprintf("%s:%d", host, port)
 }

--- a/configx/permission.go
+++ b/configx/permission.go
@@ -1,0 +1,53 @@
+package configx
+
+import (
+	"os"
+	"os/user"
+	"strconv"
+)
+
+type UnixPermission struct {
+	Owner string
+	Group string
+	Mode  os.FileMode
+}
+
+func (p *UnixPermission) SetPermission(file string) error {
+	var e error
+	e = os.Chmod(file, p.Mode)
+	if e != nil {
+		return e
+	}
+
+	gid := -1
+	uid := -1
+
+	if p.Owner != "" {
+		var userObj *user.User
+		userObj, e = user.Lookup(p.Owner)
+		if e != nil {
+			return e
+		}
+		uid, e = strconv.Atoi(userObj.Uid)
+		if e != nil {
+			return e
+		}
+	}
+	if p.Group != "" {
+		var group *user.Group
+		group, e := user.LookupGroup(p.Group)
+		if e != nil {
+			return e
+		}
+		gid, e = strconv.Atoi(group.Gid)
+		if e != nil {
+			return e
+		}
+	}
+
+	e = os.Chown(file, uid, gid)
+	if e != nil {
+		return e
+	}
+	return nil
+}

--- a/networkx/listener.go
+++ b/networkx/listener.go
@@ -1,0 +1,28 @@
+package networkx
+
+import (
+	"net"
+	"strings"
+
+	"github.com/ory/x/configx"
+)
+
+func AddressIsUnixSocket(address string) bool {
+	return strings.HasPrefix(address, "unix:")
+}
+
+func MakeListener(address string, socketPermission *configx.UnixPermission) (net.Listener, error) {
+	if AddressIsUnixSocket(address) {
+		addr := strings.TrimPrefix(address, "unix:")
+		l, err := net.Listen("unix", addr)
+		if err != nil {
+			return nil, err
+		}
+		err = socketPermission.SetPermission(addr)
+		if err != nil {
+			return nil, err
+		}
+		return l, nil
+	}
+	return net.Listen("tcp", address)
+}

--- a/networkx/listener_test.go
+++ b/networkx/listener_test.go
@@ -1,0 +1,22 @@
+package networkx
+
+import (
+       "fmt"
+       "testing"
+
+       "github.com/stretchr/testify/assert"
+)
+
+func TestAddressIsUnixSocket(t *testing.T) {
+       for k, tc := range []struct {
+               a string
+               e bool
+       }{
+               {a: "unix:/var/baz", e: true},
+               {a: "https://foo", e: false},
+       } {
+               t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
+                       assert.EqualValues(t, tc.e, AddressIsUnixSocket(tc.a))
+               })
+       }
+}


### PR DESCRIPTION
## Related issue

This has been discussed here with @aeneasr :  https://github.com/ory/kratos/issues/1249

## Proposed changes

The goal of this patch is to move helpers functions that deal with unix socket from hydra to x, so it can be used by kratos

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [X] I have added tests that prove my fix is effective or that my feature
      works.
- [X] I have added necessary documentation within the code base (if
      appropriate).
