### PR TITLE
test: import UnixPermission test from hydra

### DIFF
--- a/configx/permission_test.go
+++ b/configx/permission_test.go
@@ -1,0 +1,32 @@
+package configx
+
+import (
+        "io/ioutil"
+        "os"
+        "testing"
+
+        "github.com/stretchr/testify/assert"
+        "github.com/stretchr/testify/require"
+)
+
+func TestSetPerm(t *testing.T) {
+        f, e := ioutil.TempFile("", "test")
+        require.NoError(t, e)
+        path := f.Name()
+
+        // We cannot test setting owner and group, because we don't know what the
+        // tester has access to.
+        _ = (&UnixPermission{
+                Owner: "",
+                Group: "",
+                Mode:  0654,
+        }).SetPermission(path)
+
+        stat, err := f.Stat()
+        require.NoError(t, err)
+
+        assert.Equal(t, os.FileMode(0654), stat.Mode())
+
+        require.NoError(t, f.Close())
+        require.NoError(t, os.Remove(path))
+}


### PR DESCRIPTION
## Proposed changes

Follow-up of https://github.com/ory/x/pull/328 ; I forgot to import some unit tests that were related to the stuff imported from ory/hydra

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [X] I have added tests that prove my fix is effective or that my feature
      works.
- [X] I have added necessary documentation within the code base (if
      appropriate).
