### PR TITLE
fix: Follow $ref in array items

### DIFF
--- a/jsonschemax/keys.go
+++ b/jsonschemax/keys.go
@@ -221,14 +221,19 @@ func listPaths(schema *jsonschema.Schema, parents []string, pointers map[string]
 		case "array":
 			pathType = []interface{}{}
 			if schema.Items != nil {
-				var types []string
+				var itemSchemas []*jsonschema.Schema
 				switch t := schema.Items.(type) {
 				case []*jsonschema.Schema:
-					for _, tt := range t {
-						types = append(types, tt.Types...)
-					}
+					itemSchemas = t
 				case *jsonschema.Schema:
-					types = append(types, t.Types...)
+					itemSchemas = []*jsonschema.Schema{t}
+				}
+				var types []string
+				for _, is := range itemSchemas {
+					types = append(types, is.Types...)
+					if is.Ref != nil {
+						types = append(types, is.Ref.Types...)
+					}
 				}
 				types = stringslice.Unique(types)
 				if len(types) == 1 {
@@ -245,6 +250,9 @@ func listPaths(schema *jsonschema.Schema, parents []string, pointers map[string]
 					case "string":
 						pathType = []string{}
 						pathTypeHint = StringSlice
+					default:
+						pathType = []interface{}{}
+						pathTypeHint = JSON
 					}
 				}
 			}

--- a/jsonschemax/keys_test.go
+++ b/jsonschemax/keys_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/ory/x/assertx"
 	"io/ioutil"
 	"testing"
+
+	"github.com/ory/x/assertx"
 
 	"github.com/pkg/errors"
 
@@ -3486,6 +3487,146 @@ func TestListPaths(t *testing.T) {
     "Default": null,
     "Type": false,
     "TypeHint": 4,
+    "Format": "",
+    "Pattern": null,
+    "Enum": null,
+    "Constant": null,
+    "ReadOnly": false,
+    "MinLength": -1,
+    "MaxLength": -1,
+    "Minimum": null,
+    "Maximum": null,
+    "MultipleOf": null,
+    "CustomProperties": null
+  }
+]`),
+		},
+		{
+			schema: `{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "test.json",
+  "type": "object",
+  "definitions": {
+    "foo": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "bar": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/foo"
+      }
+    }
+  }
+}`,
+			expected: json.RawMessage(`[
+  {
+    "Title": "",
+    "Description": "",
+    "Examples": null,
+    "Name": "bar",
+    "Default": null,
+    "Type": [],
+    "TypeHint": 8,
+    "Format": "",
+    "Pattern": null,
+    "Enum": null,
+    "Constant": null,
+    "ReadOnly": false,
+    "MinLength": -1,
+    "MaxLength": -1,
+    "Minimum": null,
+    "Maximum": null,
+    "MultipleOf": null,
+    "CustomProperties": null
+  }
+]`),
+		},
+		{
+			schema: `{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "test.json",
+  "type": "object",
+  "definitions": {
+    "foo": {
+      "type": "string"
+    },
+    "bar": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/foo"
+      }
+    }
+  },
+  "properties": {
+    "baz": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/bar"
+      }
+    }
+  }
+}`,
+			expected: json.RawMessage(`[
+  {
+    "Title": "",
+    "Description": "",
+    "Examples": null,
+    "Name": "baz",
+    "Default": null,
+    "Type": [],
+    "TypeHint": 5,
+    "Format": "",
+    "Pattern": null,
+    "Enum": null,
+    "Constant": null,
+    "ReadOnly": false,
+    "MinLength": -1,
+    "MaxLength": -1,
+    "Minimum": null,
+    "Maximum": null,
+    "MultipleOf": null,
+    "CustomProperties": null
+  }
+]`),
+		},
+		{
+			schema: `{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "test.json",
+  "type": "object",
+  "definitions": {
+    "foo": {
+      "type": "string"
+    },
+    "bar": {
+      "type": "object",
+      "properties": {
+        "foo": {
+          "$ref": "#/definitions/foo"
+        }
+      }
+    }
+  },
+  "properties": {
+    "baz": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/bar"
+      }
+    }
+  }
+}`,
+			expected: json.RawMessage(`[
+  {
+    "Title": "",
+    "Description": "",
+    "Examples": null,
+    "Name": "baz",
+    "Default": null,
+    "Type": [],
+    "TypeHint": 5,
     "Format": "",
     "Pattern": null,
     "Enum": null,


### PR DESCRIPTION
## Related issue

Fixes https://github.com/ory/hydra/issues/2518

## Proposed changes

- [x] Follow `$ref` in array items schema.
- [x] Set type hint to `JSON` for array and object items. 
- [x] Add tests which reproduce original issues. 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).
