### PR TITLE
fix(popx): make migrator crdb resilient

### DIFF
--- a/decoderx/http_test.go
+++ b/decoderx/http_test.go
@@ -262,8 +262,8 @@ func TestHTTPFormDecoder(t *testing.T) {
 			expectedError: "I[#] S[#/required] missing properties",
 		},
 		{
-			d: "should indicate the true missing fields from nested form",
-			request: newRequest(t, "POST", "/",  bytes.NewBufferString(url.Values{"leaf": {"foo"}}.Encode()), httpContentTypeURLEncodedForm),
+			d:       "should indicate the true missing fields from nested form",
+			request: newRequest(t, "POST", "/", bytes.NewBufferString(url.Values{"leaf": {"foo"}}.Encode()), httpContentTypeURLEncodedForm),
 			options: []HTTPDecoderOption{
 				HTTPDecoderUseQueryAndBody(),
 				HTTPDecoderSetIgnoreParseErrorsStrategy(ParseErrorIgnoreConversionErrors),

--- a/popx/transaction_test.go
+++ b/popx/transaction_test.go
@@ -3,6 +3,7 @@ package popx
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/cockroachdb/cockroach-go/v2/crdb"
@@ -14,6 +15,10 @@ import (
 )
 
 func newDB(t *testing.T) *pop.Connection {
+	if runtime.GOOS == "windows" {
+		t.Skip("CockroachDB test suite does not support windows")
+	}
+
 	ts, err := testserver.NewTestServer()
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
