### PR TITLE
feat: parse max_idle_conn_time

### DIFF
--- a/sqlcon/connector.go
+++ b/sqlcon/connector.go
@@ -35,6 +35,7 @@ func cleanURLQuery(in url.Values) (out url.Values) {
 	out.Del("max_conns")
 	out.Del("max_idle_conns")
 	out.Del("max_conn_lifetime")
+	out.Del("max_idle_conn_time")
 	out.Del("parseTime")
 	return out
 }

--- a/sqlcon/connector_test.go
+++ b/sqlcon/connector_test.go
@@ -64,12 +64,14 @@ func TestClassifyDSN(t *testing.T) {
 }
 
 func TestCleanQueryURL(t *testing.T) {
-	a, err := url.ParseQuery("max_conn_lifetime=1h&max_idle_conns=10&max_conns=10")
+	a, err := url.ParseQuery("max_conn_lifetime=1h&max_idle_conn_time=1h&max_idle_conns=10&max_conns=10")
 	require.NoError(t, err)
 
 	b := cleanURLQuery(a)
 	assert.NotEqual(t, a, b)
 	assert.NotEqual(t, a.Encode(), b.Encode())
+	assert.Equal(t, true, strings.Contains(a.Encode(), "max_idle_conn_time"))
+	assert.Equal(t, false, strings.Contains(b.Encode(), "max_idle_conn_time"))
 	assert.Equal(t, true, strings.Contains(a.Encode(), "max_conn_lifetime"))
 	assert.Equal(t, false, strings.Contains(b.Encode(), "max_conn_lifetime"))
 }


### PR DESCRIPTION
## Related issue

This pull request is linked to ory/keto#523

## Proposed changes

This PR add a new sql database flag `max_idle_conn_time` to allow configration of https://golang.org/pkg/database/sql/#DB.SetConnMaxIdleTime

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

Note that this PR is breaking changes 