### PR TITLE
fix(dockertest): reset global resources after killing them

### DIFF
--- a/sqlcon/dockertest/test_helper.go
+++ b/sqlcon/dockertest/test_helper.go
@@ -53,6 +53,8 @@ func KillAllTestDatabases() {
 			panic(err)
 		}
 	}
+
+	resources = []*dockertest.Resource{}
 }
 
 // Register sets up OnExit.


### PR DESCRIPTION
## Related issue

Running `dockertest.KillAllTestDatabases` more than once results in a panic
```
panic: : No such container: 9bb7ffa7d4e07b7b3df91811baa3984698cfb2b5c90056a7b20de43e4e843ff1
```
because it was already killed in a previous run, but is still in the global slice.