### PR TITLE
feat: merged file system

### DIFF
--- a/fsx/merge.go
+++ b/fsx/merge.go
@@ -1,0 +1,30 @@
+package fsx
+
+import (
+	"io/fs"
+
+	"github.com/pkg/errors"
+)
+
+type merged []fs.FS
+
+var (
+	_ fs.FS = (merged)(nil)
+)
+
+// Merge multiple filesystems. Later file systems are shadowed by previous ones.
+func Merge(fss ...fs.FS) fs.FS {
+	return merged(fss)
+}
+
+func (m merged) Open(name string) (fs.File, error) {
+	for _, fsys := range m {
+		f, err := fsys.Open(name)
+		if err == nil {
+			return f, err
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return nil, errors.WithStack(err)
+		}
+	}
+	return nil, errors.WithStack(fs.ErrNotExist)
+}

--- a/fsx/merge_test.go
+++ b/fsx/merge_test.go
@@ -1,0 +1,23 @@
+package fsx
+
+import (
+	"embed"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//go:embed merge.go
+var prodFS embed.FS
+
+//go:embed merge_test.go
+var testFS embed.FS
+
+func TestMergeFS(t *testing.T) {
+	mergedFS := Merge(prodFS, testFS)
+
+	_, err := mergedFS.Open("merge.go")
+	assert.NoError(t, err)
+	_, err = mergedFS.Open("merge_test.go")
+	assert.NoError(t, err)
+}

--- a/fsx/merge_test.go
+++ b/fsx/merge_test.go
@@ -2,7 +2,10 @@ package fsx
 
 import (
 	"embed"
+	"io/fs"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -20,4 +23,6 @@ func TestMergeFS(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = mergedFS.Open("merge_test.go")
 	assert.NoError(t, err)
+	_, err = mergedFS.Open("unknown file")
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
 }

--- a/networkx/manager.go
+++ b/networkx/manager.go
@@ -14,7 +14,7 @@ import (
 )
 
 //go:embed migrations/sql/*.sql
-var migrations embed.FS
+var Migrations embed.FS
 
 type Manager struct {
 	c *pop.Connection
@@ -50,8 +50,11 @@ func (m *Manager) Determine(ctx context.Context) (*Network, error) {
 	return &p, nil
 }
 
+// MigrateUp applies pending up migrations.
+//
+// Deprecated: use fsx.Merge() instead to merge your local migrations with the ones exported here
 func (m *Manager) MigrateUp(ctx context.Context) error {
-	mm, err := popx.NewMigrationBox(migrations, popx.NewMigrator(m.c.WithContext(ctx), m.l, m.t, 0))
+	mm, err := popx.NewMigrationBox(Migrations, popx.NewMigrator(m.c.WithContext(ctx), m.l, m.t, 0))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/networkx/manager.go
+++ b/networkx/manager.go
@@ -13,6 +13,8 @@ import (
 	"github.com/ory/x/tracing"
 )
 
+// Migrations of the network manager. Apply by merging with your local migrations using
+// fsx.Merge() and then passing all to the migration box.
 //go:embed migrations/sql/*.sql
 var Migrations embed.FS
 


### PR DESCRIPTION
This adds a small utility `fs.FS` that implements a merged file system. Further, the types in `popx.Migrator` are updated so that any `fs.FS` can be used. This allows us to do ` popx.NewMigrationBox(fsx.Merge(migrations, networkx.Migrations), popx.NewMigrator(p.Connection(ctx), p.d.Logger(), nil, 0))`, which in turn properly returns the status and also implements down migrations. Marked the `networkx.MigrateUp` func as deprecated, but maybe rather delete right away?
