### PR TITLE
fix: allow to override some nested values in config.

### DIFF
--- a/configx/koanf_env.go
+++ b/configx/koanf_env.go
@@ -42,8 +42,16 @@ func NewKoanfEnv(prefix string, schema []byte) (*env.Env, error) {
 	}
 
 	decode := func(value string) (v interface{}) {
-		_ = json.Unmarshal([]byte(value), v)
-		return v
+		b := []byte(value)
+		var arr []interface{}
+		if err := json.Unmarshal(b, &arr); err == nil {
+			return &arr
+		}
+		h := map[string]interface{}{}
+		if err := json.Unmarshal(b, &h); err == nil {
+			return &h
+		}
+		return nil
 	}
 
 	return env.ProviderWithValue(prefix, ".", func(key string, value string) (string, interface{}) {

--- a/configx/provider_test.go
+++ b/configx/provider_test.go
@@ -109,6 +109,7 @@ func TestAdvancedConfigs(t *testing.T) {
 			stub:    "kratos",
 			configs: []string{"stub/kratos/kratos.yaml"},
 			isValid: true, envs: [][2]string{
+				{"SELFSERVICE_METHODS_OIDC_CONFIG_PROVIDERS", `[{"id":"google","provider":"google","mapper_url":"file:///etc/config/kratos/oidc.google.jsonnet","client_id":"client@example.com","client_secret":"secret"}]`},
 				{"DSN", "sqlite:///var/lib/sqlite/db.sqlite?_fk=true"},
 			}},
 		{

--- a/configx/stub/kratos/expected.json
+++ b/configx/stub/kratos/expected.json
@@ -81,7 +81,18 @@
         "enabled": true
       },
       "oidc": {
-        "enabled": false
+        "enabled": true,
+        "config": {
+          "providers": [
+            {
+              "id": "google",
+              "provider": "google",
+              "mapper_url": "file:///etc/config/kratos/oidc.google.jsonnet",
+              "client_id": "client@example.com",
+              "client_secret": "secret"
+            }
+          ]
+        }
       },
       "password": {
         "enabled": true

--- a/configx/stub/kratos/kratos.yaml
+++ b/configx/stub/kratos/kratos.yaml
@@ -18,6 +18,8 @@ selfservice:
   methods:
     password:
       enabled: true
+    oidc:
+      enabled: true
 
   flows:
     error:


### PR DESCRIPTION
Currently it is not possible to override some values in the config if they are nested such as `SELFSERVICE_METHODS_OIDC_CONFIG_PROVIDERS`. It is still not possible to override some values that are nested inside `array` but this at least should allow to replace the whole array with some serialized JSON struct. It is not ideal but it should have some more options to deal with injecting secrets into Kratos et al. 

## Related issue(s)
This is a follow up on https://github.com/ory/kratos/issues/1535

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

My initials investigation showed that even if I can generate nested keys for elements inside JSON arrays it is still hard to (impossible? https://github.com/knadh/koanf/issues/74) to make koanf to properly set those variables into the config:
```
I[#/selfservice/methods/oidc/config/providers] S[#/properties/selfservice/properties/methods/properties/oidc/properties/config/properties/providers/type] expected array, but got string
```
For reference Viper seems to support such cases (see: https://github.com/spf13/viper#accessing-nested-keys) and I know Viper is different kind of beast and has it's own set of problems but perhaps it is wise to look for alternative? Another option might be to use combined config that are merged into one (still not ideal but would help with secrets handling?).