### PR TITLE
fix(logrusx): do not panic on nil error

### DIFF
--- a/logrusx/helper.go
+++ b/logrusx/helper.go
@@ -131,6 +131,10 @@ func (l *Logger) WithSensitiveField(key string, value interface{}) *Logger {
 }
 
 func (l *Logger) WithError(err error) *Logger {
+	if err == nil {
+		return l
+	}
+
 	ctx := map[string]interface{}{"message": err.Error()}
 	if l.Entry.Logger.IsLevelEnabled(logrus.TraceLevel) {
 		if e, ok := err.(errorsx.StackTracer); ok {

--- a/logrusx/logrus_test.go
+++ b/logrusx/logrus_test.go
@@ -176,3 +176,15 @@ func TestTextLogger(t *testing.T) {
 		})
 	}
 }
+
+func TestLogger(t *testing.T) {
+	l := New("logrus test", "test")
+
+	t.Run("case=does not panic on nil error", func(t *testing.T) {
+		defer func() {
+			assert.Nil(t, recover())
+		}()
+
+		l.WithError(nil)
+	})
+}


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

`l.WithError` should not panic but ignore `nil` errors, like other error handling functions (e.g. `errors.WithStack()`).
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
