### PR TITLE
chore: update repository template to d066e55a

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     about: Please ask and answer questions here, show your implementations and discuss ideas.
   - name: Ory Chat
     url: https://www.ory.sh/chat
-    about: Hang out with other Ory community members and ask and answer questions.
+    about: Hang out with other Ory community members to ask and answer questions.
   - name: Ory Support for Business
     url: https://github.com/ory/open-source-support/blob/master/README.md
     about: Buy professional support for Ory X.


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/d066e55a5d42c40f34c31ef55d8eac1fdd3179c8.