### PR TITLE
fix: allow negative integers as duration in config

### DIFF
--- a/configx/provider.go
+++ b/configx/provider.go
@@ -394,6 +394,11 @@ func (p *Provider) DurationF(key string, fallback time.Duration) (val time.Durat
 		return fallback
 	}
 
+	// Workaround for negative integers. Remove it after https://github.com/knadh/koanf/pull/104 was merged.
+	if i := p.Int64(key); i != 0 {
+		return time.Duration(i)
+	}
+
 	return p.Duration(key)
 }
 

--- a/configx/provider_test.go
+++ b/configx/provider_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/inhies/go-bytesize"
 
@@ -87,6 +88,14 @@ func TestProviderMethods(t *testing.T) {
 			require.NoError(t, p.Set("invalid.request_uri", "foo"))
 			assert.Equal(t, ory, p.RequestURIF("invalid.request_uri", ory))
 		})
+	})
+
+	t.Run("allow integer as duration", func(t *testing.T) {
+		assert.NoError(t, p.Set("duration.integer1", -1))
+		assert.NoError(t, p.Set("duration.integer2", "-1"))
+
+		assert.Equal(t, -1*time.Nanosecond, p.DurationF("duration.integer1", time.Second))
+		assert.Equal(t, -1*time.Nanosecond, p.DurationF("duration.integer2", time.Second))
 	})
 
 	t.Run("use complex set operations", func(t *testing.T) {


### PR DESCRIPTION
solves ory/hydra#2651 

A temporary workaround until knadh/koanf#104 is merged. It allows us to use `-1` as a valid value for a duration in the configuration of `ory/hydra`.

## Related issue(s)
* ory/hydra#2651

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
