### PR TITLE
fix(configx): unlock provider before running watcher callbacks

### DIFF
--- a/configx/provider_watch_test.go
+++ b/configx/provider_watch_test.go
@@ -255,18 +255,19 @@ func TestReload(t *testing.T) {
 	})
 
 	t.Run("case=callback can use the provider to get the new value", func(t *testing.T) {
-		f := tmpConfigFile(t, "old", "bar")
+		dsn := "old"
+
+		f := tmpConfigFile(t, dsn, "bar")
 		c := make(chan struct{})
-		vc := make(chan string)
 
 		var p *Provider
 		p, _ = setup(t, f, c, AttachWatcher(func(watcherx.Event, error) {
-			vc <- p.String("dsn")
+			dsn = p.String("dsn")
 		}))
 
-		// change foo to bar
+		// change dsn
 		updateConfigFile(t, c, f, "new", "bar", "bar")
 
-		assert.Equal(t, "new", <-vc)
+		assert.Equal(t, "new", dsn)
 	})
 }

--- a/configx/provider_watch_test.go
+++ b/configx/provider_watch_test.go
@@ -253,4 +253,20 @@ func TestReload(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, atStartNum < 20, "should not be unreasonably high: %s\n\t%s", atStartNum, lsofAtStart)
 	})
+
+	t.Run("case=callback can use the provider to get the new value", func(t *testing.T) {
+		f := tmpConfigFile(t, "dsn", "foo")
+		c := make(chan struct{})
+		vc := make(chan string)
+
+		var p *Provider
+		p, _ = setup(t, f, c, AttachWatcher(func(watcherx.Event, error) {
+			vc <- p.String("foo")
+		}))
+
+		// change foo to bar
+		updateConfigFile(t, c, f, "dsn", "bar", "")
+
+		assert.Equal(t, "bar", <-vc)
+	})
 }

--- a/configx/provider_watch_test.go
+++ b/configx/provider_watch_test.go
@@ -255,18 +255,18 @@ func TestReload(t *testing.T) {
 	})
 
 	t.Run("case=callback can use the provider to get the new value", func(t *testing.T) {
-		f := tmpConfigFile(t, "dsn", "foo")
+		f := tmpConfigFile(t, "old", "bar")
 		c := make(chan struct{})
 		vc := make(chan string)
 
 		var p *Provider
 		p, _ = setup(t, f, c, AttachWatcher(func(watcherx.Event, error) {
-			vc <- p.String("foo")
+			vc <- p.String("dsn")
 		}))
 
 		// change foo to bar
-		updateConfigFile(t, c, f, "dsn", "bar", "")
+		updateConfigFile(t, c, f, "new", "bar", "bar")
 
-		assert.Equal(t, "bar", <-vc)
+		assert.Equal(t, "new", <-vc)
 	})
 }


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
