### PR TITLE
refactor(proxy): give host mapper the full request

### DIFF
--- a/proxy/proxy_full_test.go
+++ b/proxy/proxy_full_test.go
@@ -408,6 +408,7 @@ func TestBetweenReverseProxies(t *testing.T) {
 				Name:   "foo",
 				Value:  "setting this cookie for my own domain",
 				Domain: targetHost,
+				Secure: true,
 			})
 		}
 
@@ -423,6 +424,7 @@ func TestBetweenReverseProxies(t *testing.T) {
 		assert.Equal(t, "foo", cookies[0].Name)
 		assert.Equal(t, "setting this cookie for my own domain", cookies[0].Value)
 		assert.Equal(t, "sh", cookies[0].Domain)
+		assert.Equal(t, false, cookies[0].Secure)
 	})
 
 	t.Run("case=replaces location", func(t *testing.T) {

--- a/proxy/rewrites.go
+++ b/proxy/rewrites.go
@@ -92,7 +92,7 @@ func bodyResponseRewrite(resp *http.Response, c *HostConfig) ([]byte, *compressa
 		return nil, nil, err
 	}
 
-	return bytes.ReplaceAll(body, []byte(c.TargetHost), []byte(c.originalHost+c.PathPrefix)), cb, nil
+	return bytes.ReplaceAll(body, []byte(c.UpstreamScheme+"://"+c.TargetHost), []byte(c.originalScheme+"://"+c.originalHost+c.PathPrefix)), cb, nil
 }
 
 func readBody(h http.Header, body io.ReadCloser) ([]byte, *compressableBody, error) {

--- a/proxy/rewrites.go
+++ b/proxy/rewrites.go
@@ -63,13 +63,13 @@ func headerResponseRewrite(resp *http.Response, c *HostConfig) error {
 		resp.Header.Set("Location", redir.String())
 	}
 
-	ReplaceCookieDomain(resp, c.TargetHost, c.CookieDomain)
+	ReplaceCookieDomainAndSecure(resp, c.TargetHost, c.CookieDomain, c.originalScheme == "https")
 
 	return nil
 }
 
-// ReplaceCookieDomain replaces the domain of all matching Set-Cookie headers in the response.
-func ReplaceCookieDomain(resp *http.Response, original, replacement string) {
+// ReplaceCookieDomainAndSecure replaces the domain of all matching Set-Cookie headers in the response.
+func ReplaceCookieDomainAndSecure(resp *http.Response, original, replacement string, secure bool) {
 	original, replacement = stripPort(original), stripPort(replacement) // cookies don't distinguish ports
 
 	cookies := resp.Cookies()
@@ -77,6 +77,7 @@ func ReplaceCookieDomain(resp *http.Response, original, replacement string) {
 	for _, co := range cookies {
 		if strings.EqualFold(co.Domain, original) {
 			co.Domain = replacement
+			co.Secure = secure
 		}
 		resp.Header.Add("Set-Cookie", co.String())
 	}

--- a/proxy/rewrites_test.go
+++ b/proxy/rewrites_test.go
@@ -258,17 +258,17 @@ func TestRewrites(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
-		t.Run("case=json body with path prefix", func(t *testing.T) {
+		t.Run("case=json body with path prefix and method rewrite", func(t *testing.T) {
 			upstreamHost := "some-project-1234.oryapis.com"
 
 			c := &HostConfig{
 				CookieDomain:   "example.com",
 				TargetHost:     upstreamHost,
 				UpstreamHost:   upstreamHost,
-				UpstreamScheme: "http",
+				UpstreamScheme: "https",
 				PathPrefix:     "/foo",
 				originalHost:   "auth.example.com",
-				originalScheme: "https",
+				originalScheme: "http",
 			}
 
 			body, err := sjson.Set("{}", "some_key", "https://"+upstreamHost+"/path")
@@ -283,9 +283,9 @@ func TestRewrites(t *testing.T) {
 			b, _, err := bodyResponseRewrite(resp, c)
 			require.NoError(t, err)
 
-			assert.Equal(t, "https://auth.example.com/foo", gjson.GetBytes(b, "inner_resp.inner_key").Str, "%s", b)
-			assert.Equal(t, "https://auth.example.com/foo/path", gjson.GetBytes(b, "some_key").Str, "%s", b)
-			assert.Equal(t, "https://auth.example.com/foo/bar", gjson.GetBytes(b, "inner_resp_arr.0.inner_key").Str, "%s", b)
+			assert.Equal(t, "http://auth.example.com/foo", gjson.GetBytes(b, "inner_resp.inner_key").Str, "%s", b)
+			assert.Equal(t, "http://auth.example.com/foo/path", gjson.GetBytes(b, "some_key").Str, "%s", b)
+			assert.Equal(t, "http://auth.example.com/foo/bar", gjson.GetBytes(b, "inner_resp_arr.0.inner_key").Str, "%s", b)
 		})
 
 		t.Run("case=string body and no path prefix", func(t *testing.T) {

--- a/proxy/rewrites_test.go
+++ b/proxy/rewrites_test.go
@@ -293,7 +293,7 @@ func TestRewrites(t *testing.T) {
 				CookieDomain:   "example.com",
 				TargetHost:     "some-project-1234.oryapis.com",
 				UpstreamHost:   "some-project-1234.oryapis.com",
-				UpstreamScheme: "http",
+				UpstreamScheme: "https",
 				PathPrefix:     "/foo",
 				originalHost:   "auth.example.com",
 				originalScheme: "https",
@@ -311,17 +311,17 @@ func TestRewrites(t *testing.T) {
 				CookieDomain:   "example.com",
 				TargetHost:     "actually.host.com",
 				UpstreamHost:   "some-project-1234.oryapis.com",
-				UpstreamScheme: "http",
+				UpstreamScheme: "https",
 				PathPrefix:     "/foo",
 				originalHost:   "auth.example.com",
-				originalScheme: "https",
+				originalScheme: "http",
 			}
 
 			resp := newOKResp(fmt.Sprintf("I am available at https://%s", c.TargetHost))
 
 			replaced, _, err := bodyResponseRewrite(resp, c)
 			require.NoError(t, err)
-			assert.Equal(t, fmt.Sprintf("I am available at https://%s", c.originalHost+c.PathPrefix), string(replaced))
+			assert.Equal(t, fmt.Sprintf("I am available at http://%s", c.originalHost+c.PathPrefix), string(replaced))
 		})
 	})
 }


### PR DESCRIPTION
BREAKING CHANGE: Before, the proxy host mapper would only receive the host. However, sometimes we need more than that to match the correct config. This patch addresses that.

```patch
- type HostMapper func(ctx context.Context, host string) (*HostConfig, error)
+ type HostMapper func(ctx context.Context, r *http.Request) (*HostConfig, error)
```

/cc @Benehiko @zepatrik 

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related Issue or Design Document

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
