### PR TITLE
fix(proxy): add target scheme for replacement

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -31,6 +31,9 @@ type (
 		// TargetHost is the final target of the request. Should be the same as UpstreamHost
 		// if the request is directly passed to the target service.
 		TargetHost string
+		// TargetScheme is the final target's scheme
+		// (i.e. the scheme the target thinks it is running under)
+		TargetScheme string
 		// PathPrefix is a prefix that is prepended on the original host,
 		// but removed before forwarding.
 		PathPrefix string

--- a/proxy/proxy_full_test.go
+++ b/proxy/proxy_full_test.go
@@ -329,6 +329,7 @@ func TestFullIntegration(t *testing.T) {
 						hc.UpstreamHost = urlx.ParseOrPanic(upstreamServer.URL).Host
 						hc.UpstreamScheme = urlx.ParseOrPanic(upstreamServer.URL).Scheme
 						hc.TargetHost = hc.UpstreamHost
+						hc.TargetScheme = hc.UpstreamScheme
 					}
 					return hc, err
 				}
@@ -369,6 +370,7 @@ func TestBetweenReverseProxies(t *testing.T) {
 			CookieDomain:   "sh",
 			UpstreamHost:   urlx.ParseOrPanic(revProxy.URL).Host,
 			UpstreamScheme: urlx.ParseOrPanic(revProxy.URL).Scheme,
+			TargetScheme:   "http",
 			TargetHost:     targetHost,
 		}, nil
 	}))

--- a/proxy/rewrites.go
+++ b/proxy/rewrites.go
@@ -93,7 +93,7 @@ func bodyResponseRewrite(resp *http.Response, c *HostConfig) ([]byte, *compressa
 		return nil, nil, err
 	}
 
-	return bytes.ReplaceAll(body, []byte(c.UpstreamScheme+"://"+c.TargetHost), []byte(c.originalScheme+"://"+c.originalHost+c.PathPrefix)), cb, nil
+	return bytes.ReplaceAll(body, []byte(c.TargetScheme+"://"+c.TargetHost), []byte(c.originalScheme+"://"+c.originalHost+c.PathPrefix)), cb, nil
 }
 
 func readBody(h http.Header, body io.ReadCloser) ([]byte, *compressableBody, error) {

--- a/proxy/rewrites_test.go
+++ b/proxy/rewrites_test.go
@@ -264,6 +264,7 @@ func TestRewrites(t *testing.T) {
 			c := &HostConfig{
 				CookieDomain:   "example.com",
 				TargetHost:     upstreamHost,
+				TargetScheme:   "https",
 				UpstreamHost:   upstreamHost,
 				UpstreamScheme: "https",
 				PathPrefix:     "/foo",
@@ -292,6 +293,7 @@ func TestRewrites(t *testing.T) {
 			c := &HostConfig{
 				CookieDomain:   "example.com",
 				TargetHost:     "some-project-1234.oryapis.com",
+				TargetScheme:   "https",
 				UpstreamHost:   "some-project-1234.oryapis.com",
 				UpstreamScheme: "https",
 				PathPrefix:     "/foo",
@@ -299,17 +301,18 @@ func TestRewrites(t *testing.T) {
 				originalScheme: "https",
 			}
 
-			resp := newOKResp(fmt.Sprintf("this is a string body https://%s", c.UpstreamHost))
+			resp := newOKResp(fmt.Sprintf("this is a string body %s://%s", c.TargetScheme, c.TargetHost))
 
 			replaced, _, err := bodyResponseRewrite(resp, c)
 			require.NoError(t, err)
-			assert.Equal(t, fmt.Sprintf("this is a string body https://%s", c.originalHost+c.PathPrefix), string(replaced))
+			assert.Equal(t, fmt.Sprintf("this is a string body %s://%s", c.originalScheme, c.originalHost+c.PathPrefix), string(replaced))
 		})
 
 		t.Run("case=different target and upstream hosts", func(t *testing.T) {
 			c := &HostConfig{
 				CookieDomain:   "example.com",
 				TargetHost:     "actually.host.com",
+				TargetScheme:   "https",
 				UpstreamHost:   "some-project-1234.oryapis.com",
 				UpstreamScheme: "https",
 				PathPrefix:     "/foo",
@@ -317,11 +320,11 @@ func TestRewrites(t *testing.T) {
 				originalScheme: "http",
 			}
 
-			resp := newOKResp(fmt.Sprintf("I am available at https://%s", c.TargetHost))
+			resp := newOKResp(fmt.Sprintf("I am available at %s://%s", c.TargetScheme, c.TargetHost))
 
 			replaced, _, err := bodyResponseRewrite(resp, c)
 			require.NoError(t, err)
-			assert.Equal(t, fmt.Sprintf("I am available at http://%s", c.originalHost+c.PathPrefix), string(replaced))
+			assert.Equal(t, fmt.Sprintf("I am available at %s://%s", c.originalScheme, c.originalHost+c.PathPrefix), string(replaced))
 		})
 	})
 }


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related Issue or Design Document

The problem was that the body response replacement was not working since #426 when the upstream's and target's schemes did not match.
<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->