### PR TITLE
feat: http client tracing

### DIFF
--- a/tracing/http_client.go
+++ b/tracing/http_client.go
@@ -1,0 +1,51 @@
+package tracing
+
+import (
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	otlog "github.com/opentracing/opentracing-go/log"
+	"net/http"
+)
+
+// The RoundTripperFunc type is an adapter to allow the use of ordinary
+// functions as RoundTrippers. If f is a function with the appropriate
+// signature, RountTripperFunc(f) is a RoundTripper that calls f.
+type RoundTripperFunc func(req *http.Request) (*http.Response, error)
+
+// RoundTrip implements the RoundTripper interface.
+func (rt RoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return rt(r)
+}
+
+func RoundTripper(tracer opentracing.Tracer, delegate http.RoundTripper) http.RoundTripper {
+	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		ctx := req.Context()
+
+		saveURL := *req.URL
+		saveURL.RawQuery = ""
+		saveURL.User = nil
+
+		span, _ := opentracing.StartSpanFromContextWithTracer(ctx, tracer, "webhook", ext.SpanKindRPCClient,
+			opentracing.Tags{
+				"http.url":    saveURL.String(),
+				"http.method": req.Method,
+			})
+		defer span.Finish()
+		carrier := opentracing.HTTPHeadersCarrier(req.Header)
+		span.Tracer().Inject(span.Context(), opentracing.HTTPHeaders, carrier)
+
+		if delegate == nil {
+			delegate = http.DefaultTransport
+		}
+
+		resp, err := delegate.RoundTrip(req)
+
+		if err != nil {
+			span.SetTag("http.error", err.Error())
+			span.LogFields(otlog.Error(err))
+			return resp, err
+		}
+		ext.HTTPStatusCode.Set(span, uint16(resp.StatusCode))
+		return resp, err
+	})
+}

--- a/tracing/http_client_test.go
+++ b/tracing/http_client_test.go
@@ -1,0 +1,76 @@
+package tracing
+
+import (
+	"context"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTracingRoundTripper(t *testing.T) {
+	tracer := mocktracer.New()
+
+	// mock Round Tripper to just return a valid response
+	var mockRoundTripper http.RoundTripper = RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			Status:     http.StatusText(http.StatusNotImplemented),
+			StatusCode: http.StatusNotImplemented,
+		}, nil
+	})
+
+	rt := RoundTripper(tracer, mockRoundTripper)
+
+	parent := tracer.StartSpan("parent")
+	ctx := opentracing.ContextWithSpan(context.Background(), parent)
+	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+	req = req.WithContext(ctx)
+	res, err := rt.RoundTrip(req)
+
+	parent.Finish()
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusNotImplemented, res.StatusCode)
+
+	// Did this create the expected spans?
+	recordedSpans := tracer.FinishedSpans()
+	assert.Len(t, recordedSpans, 2)
+	assert.Equal(t, "webhook", recordedSpans[0].OperationName)
+	assert.Equal(t, "GET", recordedSpans[0].Tag("http.method"))
+	assert.Equal(t, "http://example.com/foo", recordedSpans[0].Tag("http.url"))
+	assert.Equal(t, uint16(http.StatusNotImplemented), recordedSpans[0].Tag("http.status_code"))
+
+	assert.Equal(t, recordedSpans[1].OperationName, "parent")
+}
+
+func TestTracingRoundTripper_error(t *testing.T) {
+	tracer := mocktracer.New()
+
+	var mockRoundTripper http.RoundTripper = RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("round trip failed!")
+	})
+
+	rt := RoundTripper(tracer, mockRoundTripper)
+
+	parent := tracer.StartSpan("parent")
+	ctx := opentracing.ContextWithSpan(context.Background(), parent)
+	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+	req = req.WithContext(ctx)
+	res, err := rt.RoundTrip(req)
+
+	parent.Finish()
+	assert.Error(t, err)
+	assert.Nil(t, res)
+
+	recordedSpans := tracer.FinishedSpans()
+
+	assert.Len(t, recordedSpans, 2)
+	assert.Equal(t, "webhook", recordedSpans[0].OperationName)
+	assert.Equal(t, "GET", recordedSpans[0].Tag("http.method"))
+	assert.Equal(t, "http://example.com/foo", recordedSpans[0].Tag("http.url"))
+	assert.Equal(t, "round trip failed!", recordedSpans[0].Tag("http.error"))
+	assert.NotNil(t, recordedSpans[0].FinishTime)
+	assert.Equal(t, "parent", recordedSpans[1].OperationName)
+}


### PR DESCRIPTION
Add an option to trace Http call with resilient http client.

This originates from an (Work in progress) MR for kratos: https://github.com/ory/kratos/pull/2154


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
