### PR TITLE
feat(sqlcon): Cleanup test db docker images

### DIFF
--- a/sqlcon/dockertest/test_helper_test.go
+++ b/sqlcon/dockertest/test_helper_test.go
@@ -1,0 +1,82 @@
+package dockertest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/ory/dockertest/v3"
+	dc "github.com/ory/dockertest/v3/docker"
+)
+
+type mockPool struct{ mock.Mock }
+
+func (p *mockPool) Purge(r *dockertest.Resource) error {
+	args := p.Called(r)
+	return args.Error(0)
+}
+
+func (p *mockPool) Run(repository string, tag string, env []string) (*dockertest.Resource, error) {
+	args := p.Called(repository, tag, env)
+	return args.Get(0).(*dockertest.Resource), args.Error(1)
+}
+
+func (p *mockPool) RunWithOptions(opts *dockertest.RunOptions, hcOpts ...func(*dc.HostConfig)) (*dockertest.Resource, error) {
+	args := p.Called(opts, hcOpts)
+	return args.Get(0).(*dockertest.Resource), args.Error(1)
+}
+
+func setupMock(t *testing.T) *mockPool {
+	m := &mockPool{}
+	m.Test(t)
+	pool = m
+	return m
+}
+
+func TestRunTestDBs(t *testing.T) {
+	tc := []struct {
+		name   string
+		env    string
+		testFn func(t testing.TB) string
+	}{
+		{
+			name:   "postgres",
+			env:    "TEST_DATABASE_POSTGRESQL",
+			testFn: RunTestPostgreSQL,
+		}, {
+			name:   "mysql",
+			env:    "TEST_DATABASE_MYSQL",
+			testFn: RunTestMySQL,
+		}, {
+			name:   "cockroachdb",
+			env:    "TEST_DATABASE_COCKROACHDB",
+			testFn: RunTestCockroachDB,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run("db="+tt.name, func(t *testing.T) {
+			t.Run("case=from_docker", func(t *testing.T) {
+				m := setupMock(t)
+				t.Setenv(tt.env, "")
+				resource := &dockertest.Resource{}
+				m.On("Run", mock.Anything, mock.Anything, mock.Anything).Return(resource, nil)
+				m.On("RunWithOptions", mock.Anything, mock.Anything).Return(resource, nil)
+				m.On("Purge", resource).Return(nil)
+
+				t.Run("in test", func(t *testing.T) { tt.testFn(t) })
+
+				m.AssertCalled(t, "Purge", resource)
+			})
+
+			t.Run("case=from_env", func(t *testing.T) {
+				m := setupMock(t)
+				t.Setenv(tt.env, "conn")
+
+				tt.testFn(t)
+
+				m.AssertExpectations(t)
+			})
+		})
+	}
+}


### PR DESCRIPTION
Test databases in docker images are now cleaned up automatically after the test finishes with `t.Cleanup()`.

Previously, databases started with the `dockertest.RunTest{DB}(*testing.T)` functions could not be cleaned up.

## Related Issue or Design Document

Closes Issue #460 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

* The `Run{DB}() (string, error)` family of functions still do not return something to be cleaned up by, but adding a cleanup return function would change the API.
