### PR TITLE
feat: websocket support

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"net/http/httputil"
 )
@@ -104,7 +103,7 @@ func director(o *options) func(*http.Request) {
 
 		r.Header.Del("Content-Length")
 		r.ContentLength = int64(n)
-		r.Body = io.NopCloser(cb)
+		r.Body = cb
 	}
 }
 
@@ -139,9 +138,14 @@ func modifyResponse(o *options) func(*http.Response) error {
 			return o.onResError(r, err)
 		}
 
+		n, t, err := handleWebsocketResponse(n, cb, r.Body)
+		if err != nil {
+			return err
+		}
+
 		r.Header.Del("Content-Length")
 		r.ContentLength = int64(n)
-		r.Body = io.NopCloser(cb)
+		r.Body = t
 		return nil
 	}
 }

--- a/proxy/rewrites.go
+++ b/proxy/rewrites.go
@@ -22,6 +22,9 @@ var _ io.ReadWriteCloser = new(compressableBody)
 func (b *compressableBody) Close() error {
 	if b != nil {
 		b.buf.Reset()
+		if b.w != nil {
+			return b.w.Close()
+		}
 	}
 	return nil
 }

--- a/proxy/rewrites.go
+++ b/proxy/rewrites.go
@@ -20,6 +20,9 @@ type compressableBody struct {
 var _ io.ReadWriteCloser = new(compressableBody)
 
 func (b *compressableBody) Close() error {
+	if b != nil {
+		b.buf.Reset()
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

I have come across an issue while working on SPA integration using the [Ory Cli](https://github.com/ory/cli).
When running a development server when working on SPAs the browser opens a websocket connection to the development server for debugging purposes. I noticed that the Ory Cli was dropping the connection with the error:

```
internal error: 101 switching protocols response with non-writable body
```

After further investigation, it seemed that we were returning an `io.NopCloser` and replacing the `response.Body` entirely, which means any modification done internally by the `httputil.ReverseProxy` would be overwritten.

This change allows us to use the websocket response instead with its internal modifications with our modified body.

## Related Issue or Design Document

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
