### PR TITLE
feat: support 'leak_sensitive_values' in URL params

### DIFF
--- a/logrusx/helper.go
+++ b/logrusx/helper.go
@@ -101,18 +101,18 @@ func (l *Logger) WithRequest(r *http.Request) *Logger {
 
 func (l *Logger) Logf(level logrus.Level, format string, args ...interface{}) {
 	if !l.leakSensitive {
-		var myArgs []interface{}
-		for _, arg := range args {
-			urlArg, ok := arg.(*url.URL)
-			if ok {
+		for i, arg := range args {
+			switch urlArg := arg.(type) {
+			case url.URL:
 				urlCopy := url.URL{Scheme: urlArg.Scheme, Host: urlArg.Host, Path: urlArg.Path}
-				myArgs = append(myArgs, &urlCopy)
-			} else {
-				myArgs = append(myArgs, arg)
+				args[i] = urlCopy
+			case *url.URL:
+				urlCopy := url.URL{Scheme: urlArg.Scheme, Host: urlArg.Host, Path: urlArg.Path}
+				args[i] = &urlCopy
+			default:
+				continue
 			}
 		}
-		l.Entry.Logf(level, format, myArgs...)
-		return
 	}
 	l.Entry.Logf(level, format, args...)
 }

--- a/logrusx/helper.go
+++ b/logrusx/helper.go
@@ -105,9 +105,8 @@ func (l *Logger) Logf(level logrus.Level, format string, args ...interface{}) {
 		for _, arg := range args {
 			urlArg, ok := arg.(*url.URL)
 			if ok {
-				urlCopy, _ := url.Parse(urlArg.String())
-				urlCopy.RawQuery = `Value is sensitive and has been redacted. To see the value set config key "log.leak_sensitive_values = true" or environment variable "LOG_LEAK_SENSITIVE_VALUES=true".`
-				myArgs = append(myArgs, urlCopy)
+				urlCopy := url.URL{Scheme: urlArg.Scheme, Host: urlArg.Host, Path: urlArg.Path}
+				myArgs = append(myArgs, &urlCopy)
 			} else {
 				myArgs = append(myArgs, arg)
 			}

--- a/logrusx/logrus_test.go
+++ b/logrusx/logrus_test.go
@@ -179,16 +179,14 @@ func TestTextLogger(t *testing.T) {
 		},
 		{
 			l:         tracer,
-			expect:    []string{"Value is sensitive and has been redacted. To see the value set config key \"log.leak_sensitive_values = true\" or environment variable \"LOG_LEAK_SENSITIVE_VALUES=true\"."},
-			notExpect: []string{"bar=foo"},
+			notExpect: []string{"?bar=foo"},
 			call: func(l *Logger) {
 				l.Printf("%s", fakeRequest.URL)
 			},
 		},
 		{
-			l:         New("logrusx-app", "v0.0.0", ForceFormat("text"), ForceLevel(logrus.TraceLevel), LeakSensitive()),
-			expect:    []string{"bar=foo"},
-			notExpect: []string{"Value is sensitive and has been redacted. To see the value set config key \"log.leak_sensitive_values = true\" or environment variable \"LOG_LEAK_SENSITIVE_VALUES=true\"."},
+			l:      New("logrusx-app", "v0.0.0", ForceFormat("text"), ForceLevel(logrus.TraceLevel), LeakSensitive()),
+			expect: []string{"?bar=foo"},
 			call: func(l *Logger) {
 				l.Printf("%s", fakeRequest.URL)
 			},

--- a/logrusx/logrus_test.go
+++ b/logrusx/logrus_test.go
@@ -191,6 +191,20 @@ func TestTextLogger(t *testing.T) {
 				l.Printf("%s", fakeRequest.URL)
 			},
 		},
+		{
+			l:         tracer,
+			notExpect: []string{"RawQuery:bar=foo"},
+			call: func(l *Logger) {
+				l.Printf("%+v", *fakeRequest.URL)
+			},
+		},
+		{
+			l:      New("logrusx-app", "v0.0.0", ForceFormat("text"), ForceLevel(logrus.TraceLevel), LeakSensitive()),
+			expect: []string{"RawQuery:bar=foo"},
+			call: func(l *Logger) {
+				l.Printf("%+v", *fakeRequest.URL)
+			},
+		},
 	} {
 		t.Run("case="+strconv.Itoa(k), func(t *testing.T) {
 			var b bytes.Buffer

--- a/logrusx/logrus_test.go
+++ b/logrusx/logrus_test.go
@@ -177,6 +177,22 @@ func TestTextLogger(t *testing.T) {
 				l.WithRequest(fakeRequest).Debug()
 			},
 		},
+		{
+			l:         tracer,
+			expect:    []string{"Value is sensitive and has been redacted. To see the value set config key \"log.leak_sensitive_values = true\" or environment variable \"LOG_LEAK_SENSITIVE_VALUES=true\"."},
+			notExpect: []string{"bar=foo"},
+			call: func(l *Logger) {
+				l.Printf("%s", fakeRequest.URL)
+			},
+		},
+		{
+			l:         New("logrusx-app", "v0.0.0", ForceFormat("text"), ForceLevel(logrus.TraceLevel), LeakSensitive()),
+			expect:    []string{"bar=foo"},
+			notExpect: []string{"Value is sensitive and has been redacted. To see the value set config key \"log.leak_sensitive_values = true\" or environment variable \"LOG_LEAK_SENSITIVE_VALUES=true\"."},
+			call: func(l *Logger) {
+				l.Printf("%s", fakeRequest.URL)
+			},
+		},
 	} {
 		t.Run("case="+strconv.Itoa(k), func(t *testing.T) {
 			var b bytes.Buffer


### PR DESCRIPTION
This change ensures that URL query string is not written to logs when `Logf` family of functions is used and `leakSensitive` option is disabled.
URL query can contain sensitive data, e.g. API keys.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related Issue or Design Document

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
