### PR TITLE
feat: make sensitive log value redaction text configurable

### DIFF
--- a/configx/stub/from-files/config.schema.json
+++ b/configx/stub/from-files/config.schema.json
@@ -935,6 +935,11 @@
           "title": "Leak Sensitive Log Values",
           "description": "If set will leak sensitive values (e.g. emails) in the logs."
         },
+        "redaction_text": {
+          "type": "string",
+          "title": "Sensitive log value redaction text",
+          "description": "Text to use, when redacting sensitive log value."
+        },
         "format": {
           "type": "string",
           "enum": [

--- a/configx/stub/hydra/config.schema.json
+++ b/configx/stub/hydra/config.schema.json
@@ -229,6 +229,11 @@
           "description": "Logs sensitive values such as cookie and URL parameter.",
           "default": false
         },
+        "redaction_text": {
+          "type": "string",
+          "title": "Sensitive log value redaction text",
+          "description": "Text to use, when redacting sensitive log value."
+        },
         "format": {
           "type": "string",
           "description": "Sets the log format.",

--- a/configx/stub/kratos/config.schema.json
+++ b/configx/stub/kratos/config.schema.json
@@ -935,6 +935,11 @@
           "title": "Leak Sensitive Log Values",
           "description": "If set will leak sensitive values (e.g. emails) in the logs."
         },
+        "redaction_text": {
+          "type": "string",
+          "title": "Sensitive log value redaction text",
+          "description": "Text to use, when redacting sensitive log value."
+        },
         "format": {
           "type": "string",
           "enum": [

--- a/configx/stub/multi/config.schema.json
+++ b/configx/stub/multi/config.schema.json
@@ -935,6 +935,11 @@
           "title": "Leak Sensitive Log Values",
           "description": "If set will leak sensitive values (e.g. emails) in the logs."
         },
+        "redaction_text": {
+          "type": "string",
+          "title": "Sensitive log value redaction text",
+          "description": "Text to use, when redacting sensitive log value."
+        },
         "format": {
           "type": "string",
           "enum": [

--- a/logrusx/config.schema.json
+++ b/logrusx/config.schema.json
@@ -37,6 +37,11 @@
       "title": "Leak Sensitive Log Values",
       "description": "If set will leak sensitive values (e.g. emails) in the logs.",
       "default": false
+    },
+    "redaction_text": {
+      "type": "string",
+      "title": "Sensitive log value redaction text",
+      "description": "Text to use, when redacting sensitive log value."
     }
   },
   "additionalProperties": false

--- a/logrusx/helper.go
+++ b/logrusx/helper.go
@@ -22,6 +22,7 @@ import (
 type Logger struct {
 	*logrus.Entry
 	leakSensitive bool
+	redactionText string
 	opts          []Option
 	name          string
 	version       string
@@ -171,7 +172,7 @@ func (l *Logger) maybeRedact(value interface{}) interface{} {
 		return nil
 	}
 	if !l.leakSensitive {
-		return `Value is sensitive and has been redacted. To see the value set config key "log.leak_sensitive_values = true" or environment variable "LOG_LEAK_SENSITIVE_VALUES=true".`
+		return l.redactionText
 	}
 	return value
 }

--- a/logrusx/logrus.go
+++ b/logrusx/logrus.go
@@ -23,6 +23,7 @@ type (
 		reportCaller  bool
 		exitFunc      func(int)
 		leakSensitive bool
+		redactionText string
 		hooks         []logrus.Hook
 		c             configurator
 	}
@@ -167,6 +168,12 @@ func LeakSensitive() Option {
 	}
 }
 
+func RedactionText(text string) Option {
+	return func(o *options) {
+		o.redactionText = text
+	}
+}
+
 func (c *nullConfigurator) Bool(_ string) bool {
 	return false
 }
@@ -192,6 +199,7 @@ func New(name string, version string, opts ...Option) *Logger {
 		name:          name,
 		version:       version,
 		leakSensitive: o.leakSensitive || o.c.Bool("log.leak_sensitive_values"),
+		redactionText: stringsx.DefaultIfEmpty(o.redactionText, `Value is sensitive and has been redacted. To see the value set config key "log.leak_sensitive_values = true" or environment variable "LOG_LEAK_SENSITIVE_VALUES=true".`),
 		Entry: newLogger(o.l, o).WithFields(logrus.Fields{
 			"audience": "application", "service_name": name, "service_version": version}),
 	}
@@ -203,6 +211,7 @@ func NewAudit(name string, version string, opts ...Option) *Logger {
 
 func (l *Logger) UseConfig(c configurator) {
 	l.leakSensitive = l.leakSensitive || c.Bool("log.leak_sensitive_values")
+	l.redactionText = stringsx.DefaultIfEmpty(c.String("log.redaction_text"), l.redactionText)
 	o := newOptions(append(l.opts, WithConfigurator(c)))
 	setLevel(l.Entry.Logger, o)
 	setFormatter(l.Entry.Logger, o)

--- a/logrusx/logrus_test.go
+++ b/logrusx/logrus_test.go
@@ -120,6 +120,19 @@ func TestTextLogger(t *testing.T) {
 			},
 		},
 		{
+			l: New("logrusx-app", "v0.0.0", ForceFormat("text"), ForceLevel(logrus.TraceLevel), RedactionText("redacted")),
+			expect: []string{"logrus_test.go", "logrusx_test.TestTextLogger",
+				"audience=application", "service_name=logrusx-app", "service_version=v0.0.0",
+				"An error occurred.", "headers:map[", "accept:application/json", "accept-encoding:gzip",
+				"user-agent:Go-http-client/1.1", "x-request-id:id1234", "host:127.0.0.1:63232", "method:GET",
+				"query:redacted",
+			},
+			notExpect: []string{"testing.tRunner", "bar=foo"},
+			call: func(l *Logger) {
+				l.WithRequest(fakeRequest).Error("An error occurred.")
+			},
+		},
+		{
 			l: New("logrusx-server", "v0.0.1", ForceFormat("text"), LeakSensitive(), ForceLevel(logrus.DebugLevel)),
 			expect: []string{
 				"audience=application", "service_name=logrusx-server", "service_version=v0.0.1",

--- a/stringsx/default.go
+++ b/stringsx/default.go
@@ -1,0 +1,8 @@
+package stringsx
+
+func DefaultIfEmpty(s string, defaultValue string) string {
+	if len(s) == 0 {
+		return defaultValue
+	}
+	return s
+}

--- a/stringsx/default_test.go
+++ b/stringsx/default_test.go
@@ -1,0 +1,12 @@
+package stringsx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultIfEmpty(t *testing.T) {
+	assert.Equal(t, DefaultIfEmpty("", "default"), "default")
+	assert.Equal(t, DefaultIfEmpty("custom", "default"), "custom")
+}


### PR DESCRIPTION
This pull request introduces feature to configure sensitive log value redaction text. Current redaction text "**Value is sensitive and has been redacted. To see the value set config key "log.leak_sensitive_values = true" or environment variable "LOG_LEAK_SENSITIVE_VALUES=true".**" is too long and takes considerable amount of log space. 

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments


