### PR TITLE
feat(jsonx): add test helpers that ensure keys we retrieve exist on the type

### DIFF
--- a/cmdx/printing.go
+++ b/cmdx/printing.go
@@ -3,12 +3,13 @@ package cmdx
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/goccy/go-yaml"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"io"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/goccy/go-yaml"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type (

--- a/jsonx/get.go
+++ b/jsonx/get.go
@@ -23,7 +23,7 @@ func jsonKey(f reflect.StructField) *string {
 }
 
 // AllValidJSONKeys returns all JSON keys from the struct or *struct type.
-// It does not return keys from nested structs, but embedded structs.
+// It does not return keys from nested slices, but embedded/nested structs.
 func AllValidJSONKeys(s interface{}) (keys []string) {
 	t := reflect.TypeOf(s)
 	v := reflect.ValueOf(s)

--- a/jsonx/get.go
+++ b/jsonx/get.go
@@ -36,20 +36,20 @@ func AllValidJSONKeys(s interface{}) (keys []string) {
 }
 
 // ParseEnsureKeys returns a result that has the GetRequireValidKey function.
-func ParseEnsureKeys(original interface{}, raw []byte) *result {
-	return &result{
+func ParseEnsureKeys(original interface{}, raw []byte) *Result {
+	return &Result{
 		keys:   AllValidJSONKeys(original),
 		result: gjson.ParseBytes(raw),
 	}
 }
 
-type result struct {
+type Result struct {
 	result gjson.Result
 	keys   []string
 }
 
 // GetRequireValidKey ensures that the key is valid before returning the result.
-func (r *result) GetRequireValidKey(t require.TestingT, key string) gjson.Result {
+func (r *Result) GetRequireValidKey(t require.TestingT, key string) gjson.Result {
 	require.Contains(t, r.keys, key)
 	return r.result.Get(key)
 }

--- a/jsonx/get.go
+++ b/jsonx/get.go
@@ -1,0 +1,61 @@
+package jsonx
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/ory/x/stringslice"
+)
+
+// AllValidJSONKeys returns all JSON keys from the struct or *struct type.
+// It does not return keys from nested structs, but embedded structs.
+func AllValidJSONKeys(s interface{}) (keys []string) {
+	t := reflect.TypeOf(s)
+	v := reflect.ValueOf(s)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+		v = v.Elem()
+	}
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if jsonTag := f.Tag.Get("json"); jsonTag != "" {
+			if jsonTag == "-" {
+				continue
+			}
+			keys = append(keys, strings.Split(jsonTag, ",")[0])
+		} else if f.IsExported() {
+			if f.Anonymous {
+				keys = append(keys, AllValidJSONKeys(v.Field(i).Interface())...)
+			} else {
+				keys = append(keys, f.Name)
+			}
+		}
+	}
+	return keys
+}
+
+// ParseEnsureKeys returns a result that has the GetRequireValidKey function.
+func ParseEnsureKeys(original interface{}, raw []byte) *result {
+	return &result{
+		keys:   AllValidJSONKeys(original),
+		result: gjson.ParseBytes(raw),
+	}
+}
+
+type result struct {
+	result gjson.Result
+	keys   []string
+}
+
+// GetRequireValidKey ensures that the key is valid before returning the result.
+func (r *result) GetRequireValidKey(t require.TestingT, key string) gjson.Result {
+	require.True(t, stringslice.Has(r.keys, key))
+	return r.result.Get(key)
+}
+
+func GetRequireValidKey(t require.TestingT, original interface{}, raw []byte, key string) gjson.Result {
+	return ParseEnsureKeys(original, raw).GetRequireValidKey(t, key)
+}

--- a/jsonx/get.go
+++ b/jsonx/get.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
-
-	"github.com/ory/x/stringslice"
 )
 
 // AllValidJSONKeys returns all JSON keys from the struct or *struct type.
@@ -52,7 +50,7 @@ type result struct {
 
 // GetRequireValidKey ensures that the key is valid before returning the result.
 func (r *result) GetRequireValidKey(t require.TestingT, key string) gjson.Result {
-	require.True(t, stringslice.Has(r.keys, key))
+	require.Contains(t, r.keys, key)
 	return r.result.Get(key)
 }
 

--- a/jsonx/get_test.go
+++ b/jsonx/get_test.go
@@ -1,0 +1,109 @@
+package jsonx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestGetJSONKeys(t *testing.T) {
+	type A struct {
+		B string
+	}
+
+	for _, tc := range []struct {
+		name     string
+		input    interface{}
+		expected []string
+	}{
+		{
+			name: "simple struct",
+			input: struct {
+				A, B string
+			}{},
+			expected: []string{"A", "B"},
+		},
+		{
+			name: "struct with json tags",
+			input: struct {
+				A string `json:"a"`
+				B string `json:"b"`
+			}{},
+			expected: []string{"a", "b"},
+		},
+		{
+			name: "struct with unexported field",
+			input: struct {
+				A, b string
+				C    string `json:"c"`
+			}{},
+			expected: []string{"A", "c"},
+		},
+		{
+			name: "struct with omitempty",
+			input: struct {
+				A string `json:"a"`
+				B string `json:"b,omitempty"`
+			}{
+				B: "we have to set this to a non-empty value because gjson keys collection will not work otherwise",
+			},
+			expected: []string{"a", "b"},
+		},
+		{
+			name: "pointer to struct",
+			input: &struct {
+				A string
+			}{},
+			expected: []string{"A"},
+		},
+		{
+			name: "embedded struct",
+			input: struct {
+				A
+			}{},
+			expected: []string{"B"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, AllValidJSONKeys(tc.input))
+
+			// collect keys with gjson, which only works reliably for non-omitempty fields
+			var keys []string
+			gjson.Parse(TestMarshalJSONString(t, tc.input)).ForEach(func(key, value gjson.Result) bool {
+				keys = append(keys, key.String())
+				return true
+			})
+			assert.ElementsMatch(t, tc.expected, keys)
+		})
+	}
+}
+
+func TestResultGetValidKey(t *testing.T) {
+	t.Run("case=fails on invalid key", func(t *testing.T) {
+		r := ParseEnsureKeys(struct{ A string }{}, []byte("{}"))
+		assert.Panics(t, func() {
+			r.GetRequireValidKey(&panicFail{}, "b")
+		})
+	})
+
+	t.Run("case=does not fail on valid key", func(t *testing.T) {
+		r := ParseEnsureKeys(struct{ A string }{}, []byte(`{"A":"a"}`))
+		var v string
+		require.NotPanics(t, func() {
+			v = r.GetRequireValidKey(&panicFail{}, "A").Str
+		})
+		assert.Equal(t, "a", v)
+	})
+}
+
+var _ require.TestingT = (*panicFail)(nil)
+
+type panicFail struct{}
+
+func (*panicFail) Errorf(string, ...interface{}) {}
+
+func (*panicFail) FailNow() {
+	panic("failing")
+}


### PR DESCRIPTION
As discussed previously with @Benehiko 

These testhelpers can be used to ensure that keys are always up-to-date in tests.