### PR TITLE
Added string to string map lookup to flagx

### DIFF
--- a/flagx/flagx.go
+++ b/flagx/flagx.go
@@ -59,6 +59,15 @@ func MustGetStringArray(cmd *cobra.Command, name string) []string {
 	return ss
 }
 
+// MustGetStringToStringMap returns a map[string]string flag or fatals if an error occurs.
+func MustGetStringToStringMap(cmd *cobra.Command, name string) map[string]string {
+	ss, err := cmd.Flags().GetStringToString(name)
+	if err != nil {
+		cmdx.Fatalf(err.Error())
+	}
+	return ss
+}
+
 // MustGetInt returns a int flag or fatals if an error occurs.
 func MustGetInt(cmd *cobra.Command, name string) int {
 	ss, err := cmd.Flags().GetInt(name)

--- a/flagx/flagx_test.go
+++ b/flagx/flagx_test.go
@@ -1,1 +1,28 @@
 package flagx
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestStringToStringCommand(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().StringToString("map-value", nil, "test string to string map usage")
+
+	cmd.SetArgs([]string{"--map-value", "foo=bar,key=val"})
+	cmd.Execute()
+
+	mapped := MustGetStringToStringMap(cmd, "map-value")
+
+	if len(mapped) != 2 {
+		t.Errorf("expected 2 values in map and got %d", len(mapped))
+	}
+	val, ok := mapped["foo"]
+	if !ok {
+		t.Errorf("failed to get value 'foo' from flags")
+	}
+	if val != "bar" {
+		t.Errorf("failed to get expected value from map, got %s", val)
+	}
+}


### PR DESCRIPTION
## Related Issue or Design Document
Added `MustGetStringToStringMap()` to `github.com/ory/x/flagx` to enable use of key/val lookups from Cobra commands.

This will allow for example, updating the Hydra CLI to pass metadata as flags:
```
hydra clients create --metadata foo=bar,key=val
```

```go
map[string]string{
  "foo": "bar",
  "key": "val",
}
```

If this makes sense I will open a separate issue and PR on Hydra to add the appropriate changes to make use of this function there.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).
