### PR TITLE
feat: improve usability of `snapshotx`

### DIFF
--- a/cloudx/cmd_update_identity_config_test.go
+++ b/cloudx/cmd_update_identity_config_test.go
@@ -36,14 +36,14 @@ func TestProjectIdentityConfig(t *testing.T) {
 			"courier.smtp.from_name",
 		})
 
-		snapshotx.SnapshotTExcept(t, json.RawMessage(stdout), []string{
+		snapshotx.SnapshotT(t, json.RawMessage(stdout), snapshotx.ExceptPaths(
 			"serve.public.base_url",
 			"serve.admin.base_url",
 			"session.cookie.domain",
 			"session.cookie.name",
 			"cookies.domain",
 			"courier.smtp.from_name",
-		})
+		))
 	})
 
 	t.Run("prints good error messages for failing schemas", func(t *testing.T) {
@@ -51,7 +51,7 @@ func TestProjectIdentityConfig(t *testing.T) {
 		require.ErrorIs(t, err, cmdx.ErrNoPrintButFail)
 
 		t.Run("stdout", func(t *testing.T) {
-			snapshotx.SnapshotTExcept(t, stdout, nil)
+			snapshotx.SnapshotT(t, stdout)
 		})
 
 		t.Run("stderr", func(t *testing.T) {

--- a/cloudx/cmd_update_project_test.go
+++ b/cloudx/cmd_update_project_test.go
@@ -40,7 +40,7 @@ func TestUpdateProject(t *testing.T) {
 			"services.identity.config.session.cookie",
 		})
 
-		snapshotx.SnapshotTExcept(t, json.RawMessage(stdout), []string{
+		snapshotx.SnapshotT(t, json.RawMessage(stdout), snapshotx.ExceptPaths(
 			"id",
 			"revision_id",
 			"slug",
@@ -49,7 +49,7 @@ func TestUpdateProject(t *testing.T) {
 			"services.identity.config.session.cookie.domain",
 			"services.identity.config.session.cookie.name",
 			"services.identity.config.cookies.domain",
-		})
+		))
 	})
 	t.Run("is able to update a projects name", func(t *testing.T) {
 		name := fakeName()
@@ -64,7 +64,7 @@ func TestUpdateProject(t *testing.T) {
 		require.ErrorIs(t, err, cmdx.ErrNoPrintButFail)
 
 		t.Run("stdout", func(t *testing.T) {
-			snapshotx.SnapshotTExcept(t, stdout, nil)
+			snapshotx.SnapshotT(t, stdout)
 		})
 		t.Run("stderr", func(t *testing.T) {
 			assert.Contains(t, stderr, "oneOf failed")

--- a/configx/koanf_schema_defaults_test.go
+++ b/configx/koanf_schema_defaults_test.go
@@ -33,5 +33,5 @@ func TestKoanfSchemaDefaults(t *testing.T) {
 
 	require.NoError(t, k.Load(def, nil))
 
-	snapshotx.SnapshotTExcept(t, k.All(), nil)
+	snapshotx.SnapshotT(t, k.All())
 }

--- a/jsonschemax/keys_test.go
+++ b/jsonschemax/keys_test.go
@@ -117,7 +117,7 @@ func TestListPathsWithRecursion(t *testing.T) {
 			actual, err := ListPathsWithRecursion(context.Background(), "test.json", c, tc.recursion)
 			require.NoError(t, err)
 
-			snapshotx.SnapshotTExcept(t, actual, nil)
+			snapshotx.SnapshotT(t, actual)
 		})
 	}
 }
@@ -296,7 +296,7 @@ func TestListPaths(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			snapshotx.SnapshotTExcept(t, actual, nil)
+			snapshotx.SnapshotT(t, actual)
 		})
 	}
 }

--- a/jsonx/embed_test.go
+++ b/jsonx/embed_test.go
@@ -35,7 +35,7 @@ func TestEmbedSources(t *testing.T) {
 				))
 				require.NoError(t, err)
 
-				snapshotx.SnapshotTExcept(t, actual, nil)
+				snapshotx.SnapshotT(t, actual)
 			})
 
 			return nil
@@ -48,7 +48,7 @@ func TestEmbedSources(t *testing.T) {
 		))
 		require.NoError(t, err)
 
-		snapshotx.SnapshotTExcept(t, actual, nil)
+		snapshotx.SnapshotT(t, actual)
 	})
 
 	t.Run("fails on invalid source", func(t *testing.T) {

--- a/snapshotx/.snapshots/TestDeleteMatches-file=1.json-fn.json
+++ b/snapshotx/.snapshots/TestDeleteMatches-file=1.json-fn.json
@@ -1,4 +1,7 @@
 {
+  "foo": {
+    "other": "fdsa"
+  },
   "nested": {
     "nested": {
       "arr": [

--- a/snapshotx/fixtures/1.json
+++ b/snapshotx/fixtures/1.json
@@ -1,9 +1,16 @@
 {
-  "ignore": [
+  "ignore_nested": [
     "updated_at",
     "created_at"
   ],
+  "ignore_exact": [
+    "foo.id"
+  ],
   "content": {
+    "foo": {
+      "id": "asdf",
+      "other": "fdsa"
+    },
     "created_at": "1234",
     "updated_at": "1234",
     "nested":{

--- a/snapshotx/fixtures/2.json
+++ b/snapshotx/fixtures/2.json
@@ -1,5 +1,5 @@
 {
-  "ignore": [
+  "ignore_nested": [
   ],
   "content": {
     "created_at": "1234",

--- a/snapshotx/fixtures/3.json
+++ b/snapshotx/fixtures/3.json
@@ -1,5 +1,5 @@
 {
-  "ignore": [
+  "ignore_nested": [
     "created_at"
   ],
   "content": {

--- a/snapshotx/snapshot_test.go
+++ b/snapshotx/snapshot_test.go
@@ -38,11 +38,12 @@ func TestDeleteMatches(t *testing.T) {
 	for k, f := range files {
 		t.Run(fmt.Sprintf("file=%s/fn", k), func(t *testing.T) {
 			var tc struct {
-				Content json.RawMessage `json:"content"`
-				Ignore  []string        `json:"ignore"`
+				Content      json.RawMessage `json:"content"`
+				IgnoreNested []string        `json:"ignore_nested"`
+				IgnoreExact  []string        `json:"ignore_exact"`
 			}
 			require.NoError(t, json.Unmarshal(f, &tc))
-			SnapshotTExceptMatchingKeys(t, tc.Content, tc.Ignore)
+			SnapshotT(t, tc.Content, ExceptNestedKeys(tc.IgnoreNested), ExceptPaths(tc.IgnoreExact))
 		})
 	}
 }

--- a/snapshotx/snapshot_test.go
+++ b/snapshotx/snapshot_test.go
@@ -43,7 +43,7 @@ func TestDeleteMatches(t *testing.T) {
 				IgnoreExact  []string        `json:"ignore_exact"`
 			}
 			require.NoError(t, json.Unmarshal(f, &tc))
-			SnapshotT(t, tc.Content, ExceptNestedKeys(tc.IgnoreNested), ExceptPaths(tc.IgnoreExact))
+			SnapshotT(t, tc.Content, ExceptNestedKeys(tc.IgnoreNested...), ExceptPaths(tc.IgnoreExact...))
 		})
 	}
 }


### PR DESCRIPTION
Currently you can either ignore all matching OR exact keys. With this PR we have the ability to use both options at the same time.

Main use case: ignore all `created_at` timestamps and only ignore the root `id`.