### PR TITLE
feat: TLS certs auto-reload

### DIFF
--- a/tlsx/cert_provider.go
+++ b/tlsx/cert_provider.go
@@ -109,7 +109,7 @@ func (p *provider) LoadCertificates(
 	if fromFiles {
 		p.certPath = certPath
 		p.keyPath = keyPath
-		p.setWatcher(certPath, keyPath)
+		return p.setWatcher(certPath, keyPath)
 	} else {
 		p.certPath = ""
 		p.keyPath = ""
@@ -146,7 +146,7 @@ func (p *provider) setCertificates(crts []tls.Certificate) {
 	p.crtsLck.Unlock()
 }
 
-func (p *provider) setWatcher(certPath, keyPath string) {
+func (p *provider) setWatcher(certPath, keyPath string) error {
 	p.watchersLck.Lock()
 	defer p.watchersLck.Unlock()
 
@@ -155,17 +155,18 @@ func (p *provider) setWatcher(certPath, keyPath string) {
 	root := filepath.Dir(certPath)
 	if root == filepath.Dir(keyPath) {
 		if err := p.addDirectoryWatcher(root); err != nil && p.ev != nil {
-			p.ev <- &ErrorEvent{error: err}
+			return err
 		}
 	} else {
 		if err := p.addFileWatcher(certPath); err != nil && p.ev != nil {
-			p.ev <- &ErrorEvent{error: err}
+			return err
 		}
 
 		if err := p.addFileWatcher(keyPath); err != nil && p.ev != nil {
-			p.ev <- &ErrorEvent{error: err}
+			return err
 		}
 	}
+	return nil
 }
 
 func (p *provider) addDirectoryWatcher(fsPath string) error {

--- a/tlsx/cert_provider.go
+++ b/tlsx/cert_provider.go
@@ -97,7 +97,7 @@ func (p *provider) LoadCertificates(
 	} else {
 		p.certPath = ""
 		p.keyPath = ""
-		p.deleteWatcher()
+		p.deleteWatchers()
 	}
 
 	return nil
@@ -138,7 +138,7 @@ func (p *provider) addWatcher(fsPath string) error {
 	return nil
 }
 
-func (p *provider) deleteWatcher() {
+func (p *provider) deleteWatchers() {
 	p.watchersLck.Lock()
 	defer p.watchersLck.Unlock()
 

--- a/tlsx/cert_provider.go
+++ b/tlsx/cert_provider.go
@@ -1,0 +1,188 @@
+package tlsx
+
+import (
+	"context"
+	"crypto/tls"
+	"path"
+	"sync"
+	"time"
+
+	"github.com/ory/x/logrusx"
+	"github.com/ory/x/watcherx"
+	"github.com/pkg/errors"
+)
+
+type (
+	Provider interface {
+		GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error)
+		LoadCertificates(certString, keyString string, certPath, keyPath string) error
+	}
+
+	provider struct {
+		ctx    context.Context
+		logger *logrusx.Logger
+
+		certPath, keyPath string
+
+		crts    []tls.Certificate
+		crtsLck sync.RWMutex
+
+		watchersCancel []func()
+		fsEvent        watcherx.EventChannel
+		watchersLck    sync.Mutex
+	}
+)
+
+// NewProvider creates a tls.Certificate provider
+func NewProvider(ctx context.Context, l *logrusx.Logger) Provider {
+	p := &provider{
+		ctx:    ctx,
+		logger: l,
+
+		fsEvent: make(watcherx.EventChannel, 1),
+	}
+
+	go p.watchCertificatesChanges()
+
+	return p
+}
+
+func (p *provider) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	p.crtsLck.RLock()
+	defer p.crtsLck.RUnlock()
+
+	if len(p.crts) == 0 {
+		return nil, errors.New("No certificate loaded")
+	}
+
+	if hello != nil {
+		for _, cert := range p.crts {
+			if cert.Leaf != nil && cert.Leaf.VerifyHostname(hello.ServerName) == nil {
+				return &cert, nil
+			}
+		}
+	}
+	return &p.crts[0], nil
+}
+
+func (p *provider) LoadCertificates(
+	certString, keyString string,
+	certPath, keyPath string,
+) error {
+	fromFiles := certPath != "" && keyPath != ""
+	crts, err := Certificate(certString, keyString, certPath, keyPath)
+	if err != nil {
+		return err
+	}
+
+	p.setCertificates(crts)
+
+	if fromFiles {
+		p.certPath = certPath
+		p.keyPath = keyPath
+		p.setWatcher(certPath, keyPath)
+	} else {
+		p.certPath = ""
+		p.keyPath = ""
+		p.deleteWatcher()
+	}
+
+	return nil
+}
+
+func (p *provider) setCertificates(crts []tls.Certificate) {
+	p.crtsLck.Lock()
+	p.crts = crts
+	p.crtsLck.Unlock()
+}
+
+func (p *provider) setWatcher(certPath, keyPath string) {
+	p.watchersLck.Lock()
+	defer p.watchersLck.Unlock()
+
+	p.deleteWatchersNoLock()
+
+	certPath = path.Dir(certPath)
+	keyPath = path.Dir(keyPath)
+
+	if err := p.addWatcher(certPath); err != nil {
+		p.logger.WithError(err).Fatalf("Could not create watcher with path: " + certPath)
+	}
+
+	if certPath == keyPath {
+		return
+	}
+
+	if err := p.addWatcher(keyPath); err != nil {
+		p.logger.WithError(err).Fatalf("Could not create watcher with path: " + keyPath)
+	}
+
+}
+
+func (p *provider) addWatcher(fsPath string) error {
+	ctx, cancel := context.WithCancel(p.ctx)
+	_, err := watcherx.WatchDirectory(ctx, fsPath, p.fsEvent)
+	if err != nil {
+		cancel()
+		return err
+	}
+
+	p.watchersCancel = append(p.watchersCancel, cancel)
+
+	return nil
+}
+
+func (p *provider) deleteWatcher() {
+	p.watchersLck.Lock()
+	defer p.watchersLck.Unlock()
+
+	p.deleteWatchersNoLock()
+}
+
+func (p *provider) deleteWatchersNoLock() {
+	for _, cancel := range p.watchersCancel {
+		cancel()
+	}
+	p.watchersCancel = nil
+}
+
+func (p *provider) watchCertificatesChanges() {
+	go func() {
+		for {
+			select {
+			case <-p.ctx.Done():
+				return
+			case _, ok := <-p.fsEvent:
+				if !ok {
+					return
+				}
+
+				p.waitForAllFilesChanges()
+
+				p.logger.Infof("TLS certificates changed, updating")
+				if err := p.LoadCertificates("", "", p.certPath, p.keyPath); err != nil {
+					p.logger.WithError(err).Errorf("Error in the new tls certificates")
+					return
+				}
+			}
+		}
+	}()
+}
+
+func (p *provider) waitForAllFilesChanges() {
+	flushUntil := time.After(2 * time.Second)
+	p.logger.Infof("TLS certificates files changed, waiting for changes to finish")
+	stop := false
+	for {
+		select {
+		case <-flushUntil:
+			stop = true
+		case <-p.fsEvent:
+			continue
+		}
+
+		if stop {
+			break
+		}
+	}
+}

--- a/tlsx/cert_provider.go
+++ b/tlsx/cert_provider.go
@@ -32,7 +32,7 @@ type (
 		watchersLck    sync.Mutex
 	}
 
-	CertificateGenerator func() []tls.Certificate
+	CertificateGenerator func() ([]tls.Certificate, error)
 )
 
 // NewProvider creates a tls.Certificate provider
@@ -79,7 +79,10 @@ func (p *provider) LoadCertificates(
 	fromFiles := certPath != "" && keyPath != ""
 	crts, err := Certificate(certString, keyString, certPath, keyPath)
 	if err != nil && errors.Is(err, ErrNoCertificatesConfigured) && p.certGen != nil {
-		crts = p.certGen()
+		crts, err = p.certGen()
+		if err != nil {
+			return err
+		}
 		fromFiles = false
 	} else if err != nil {
 		return err

--- a/tlsx/cert_provider.go
+++ b/tlsx/cert_provider.go
@@ -113,11 +113,11 @@ func (p *provider) setWatcher(certPath, keyPath string) {
 	p.deleteWatchersNoLock()
 
 	if err := p.addWatcher(certPath); err != nil {
-		p.logger.WithError(err).Fatalf("Could not create watcher with path: " + certPath)
+		p.logger.WithError(err).Fatalf("Could not create watcher with path: %s", certPath)
 	}
 
 	if err := p.addWatcher(keyPath); err != nil {
-		p.logger.WithError(err).Fatalf("Could not create watcher with path: " + keyPath)
+		p.logger.WithError(err).Fatalf("Could not create watcher with path: %s", keyPath)
 	}
 
 }

--- a/tlsx/cert_provider_test.go
+++ b/tlsx/cert_provider_test.go
@@ -1,144 +1,245 @@
 package tlsx
 
-// func TestCertProvider(t *testing.T) {
-// 	tmpDir, err := ioutil.TempDir(os.TempDir(), "test_cert_provider")
-// 	require.NoError(t, err)
-//
-// 	defer os.RemoveAll(tmpDir)
-//
-// 	logger := logrusx.New("", "")
-// 	cert1Data := []byte("cert1")
-// 	cert1 := tls.Certificate{Certificate: [][]byte{cert1Data}}
-// 	cert2Data := []byte("cert2")
-// 	cert2 := tls.Certificate{Certificate: [][]byte{cert2Data}}
-//
-// 	certLoad := CertLoadFunc(func() ([]tls.Certificate, error) {
-// 		return []tls.Certificate{cert2}, nil
-// 	})
-//
-// 	crtLoc := CertLocation{
-// 		KeyPath:  path.Join(tmpDir, "tls.key"),
-// 		CertPath: path.Join(tmpDir, "tls.crt"),
-// 	}
-// 	provider := NewCertProvider(
-// 		[]tls.Certificate{cert1},
-// 		crtLoc,
-// 		certLoad,
-// 		logger,
-// 	)
-// 	defer provider.Stop()
-//
-// 	//Checking initial cert load
-// 	cert, err := provider.GetCertificate(nil)
-// 	require.NoError(t, err)
-// 	assert.Equal(t, cert1Data, cert.Certificate[0])
-//
-// 	//Touching tls.key to trigger fs change
-// 	_, err = os.Create(crtLoc.KeyPath)
-// 	require.NoError(t, err)
-//
-// 	//The first tls.Certificate should stay before the reloading process
-// 	cert, err = provider.GetCertificate(nil)
-// 	require.NoError(t, err)
-// 	assert.Equal(t, cert1Data, cert.Certificate[0])
-//
-// 	//New cert should be loaded
-// 	time.Sleep(3 * time.Second)
-// 	cert, err = provider.GetCertificate(nil)
-// 	require.NoError(t, err)
-// 	assert.Equal(t, cert2Data, cert.Certificate[0])
-// }
-//
-// func TestCertProviderDualDir(t *testing.T) {
-// 	tmpDir, err := ioutil.TempDir(os.TempDir(), "test_cert_provider")
-// 	require.NoError(t, err)
-// 	defer os.RemoveAll(tmpDir)
-//
-// 	tmpDir2, err := ioutil.TempDir(os.TempDir(), "test_cert_provider")
-// 	require.NoError(t, err)
-// 	defer os.RemoveAll(tmpDir2)
-//
-// 	logger := logrusx.New("", "")
-// 	cert1Data := []byte("cert1")
-// 	cert1 := tls.Certificate{Certificate: [][]byte{cert1Data}}
-// 	cert2Data := []byte("cert2")
-// 	cert2 := tls.Certificate{Certificate: [][]byte{cert2Data}}
-//
-// 	certLoad := CertLoadFunc(func() ([]tls.Certificate, error) {
-// 		return []tls.Certificate{cert2}, nil
-// 	})
-//
-// 	crtLoc := CertLocation{
-// 		KeyPath:  path.Join(tmpDir, "tls.key"),
-// 		CertPath: path.Join(tmpDir2, "tls.crt"),
-// 	}
-// 	provider := NewCertProvider(
-// 		[]tls.Certificate{cert1},
-// 		crtLoc,
-// 		certLoad,
-// 		logger,
-// 	)
-// 	defer provider.Stop()
-//
-// 	//Checking initial cert load
-// 	cert, err := provider.GetCertificate(nil)
-// 	require.NoError(t, err)
-// 	assert.Equal(t, cert1Data, cert.Certificate[0])
-//
-// 	//Touching tls.crt to trigger fs change
-// 	_, err = os.Create(crtLoc.CertPath)
-// 	require.NoError(t, err)
-//
-// 	//The first tls.Certificate should stay before the reloading process
-// 	cert, err = provider.GetCertificate(nil)
-// 	require.NoError(t, err)
-// 	assert.Equal(t, cert1Data, cert.Certificate[0])
-//
-// 	//New cert should be loaded
-// 	time.Sleep(3 * time.Second)
-// 	cert, err = provider.GetCertificate(nil)
-// 	require.NoError(t, err)
-// 	assert.Equal(t, cert2Data, cert.Certificate[0])
-// }
-//
-// func TestCertProviderErrorReload(t *testing.T) {
-// 	tmpDir, err := ioutil.TempDir(os.TempDir(), "test_cert_provider")
-// 	require.NoError(t, err)
-//
-// 	defer os.RemoveAll(tmpDir)
-//
-// 	logger := logrusx.New("", "")
-// 	cert1Data := []byte("cert1")
-// 	cert1 := tls.Certificate{Certificate: [][]byte{cert1Data}}
-//
-// 	certLoad := CertLoadFunc(func() ([]tls.Certificate, error) {
-// 		return nil, errors.New("Test error")
-// 	})
-//
-// 	crtLoc := CertLocation{
-// 		KeyPath:  path.Join(tmpDir, "tls.key"),
-// 		CertPath: path.Join(tmpDir, "tls.crt"),
-// 	}
-// 	provider := NewCertProvider(
-// 		[]tls.Certificate{cert1},
-// 		crtLoc,
-// 		certLoad,
-// 		logger,
-// 	)
-// 	defer provider.Stop()
-//
-// 	//Checking initial cert load
-// 	cert, err := provider.GetCertificate(nil)
-// 	require.NoError(t, err)
-// 	assert.Equal(t, cert1Data, cert.Certificate[0])
-//
-// 	//Touching tls.key to trigger fs change
-// 	_, err = os.Create(crtLoc.KeyPath)
-// 	require.NoError(t, err)
-//
-// 	//Old cert should stay
-// 	time.Sleep(3 * time.Second)
-// 	cert, err = provider.GetCertificate(nil)
-// 	require.NoError(t, err)
-// 	assert.Equal(t, cert1Data, cert.Certificate[0])
-// }
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCertProvider(t *testing.T) {
+	k1priv := `-----BEGIN PRIVATE KEY-----
+MIIBVAIBADANBgkqhkiG9w0BAQEFAASCAT4wggE6AgEAAkEAu+t3oH41zzzesJWw
+LDj36bdf/Q7Aad6jsL1LCSv2FL6557v2dT6BTV+VzWtZC8uZUVwdBTHvEujc8xh8
+Dn9OYQIDAQABAkEAop14v6F33wXFjvl5oksJ/W152vpQ90x6Sg8ER8OLBxcmhEIq
+aDswT/54DpmCeLhTIK81Mu4bZIa+vgvxyzUAAQIhAPaNhg0B6/26K3aLsmg1lZHI
+XkOr6XssjiSsaeyvZ3IBAiEAwx7NhG7/7DbMOhC2AsZF3YgvxAhppcJN/lkyAm3V
+HGECIDoX6qgR9dsZDLin/eeUCKQLBDsJvL/rJar6fRLp2YQBAiA07r9MRRyShU8k
+FXJ7EDTV42Mp6CpY+HxWGvZxKECfIQIgVhzRaKvw6iHtcmZMNL/QORBN01GGRFxy
+JSVeA4IKnLY=
+-----END PRIVATE KEY-----`
+	k1crt := `-----BEGIN CERTIFICATE-----
+MIIB4TCCAYugAwIBAgIUO9GxImIjDW94nod81+3oixgbDTQwDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMjA2MDgwNzQxMzVaFw0yMzA2
+MDgwNzQxMzVaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwXDANBgkqhkiG9w0BAQEF
+AANLADBIAkEAu+t3oH41zzzesJWwLDj36bdf/Q7Aad6jsL1LCSv2FL6557v2dT6B
+TV+VzWtZC8uZUVwdBTHvEujc8xh8Dn9OYQIDAQABo1MwUTAdBgNVHQ4EFgQUVXSc
+VIG7royHzQxJRYvLSQr+04MwHwYDVR0jBBgwFoAUVXScVIG7royHzQxJRYvLSQr+
+04MwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAANBAHEQjXMZGbzfeYs8
+GUJIoNOf7oVKQF1fLnBvMr3dYZM1NaAORIMCphbANylV54q+mvoQodhYrI/rWxjO
+gRjJAsU=
+-----END CERTIFICATE-----`
+	k2priv := `-----BEGIN PRIVATE KEY-----
+MIIBVAIBADANBgkqhkiG9w0BAQEFAASCAT4wggE6AgEAAkEAvaiL9hSWw/a7CmHD
+AXBfFn0Tx/Pm4YuwjJY0T/j+agTkKATVwN1JM+FRnVjtSXurztn4CMV8sM0ynTpU
+IxenWwIDAQABAkB5ow+g07OeGy/6iJi444kYsz9sjlEVdrHUeME0SU1iUIOkboPH
+/ZXKieFTKltEygldeTccRC+eyD+qwQLYpY8BAiEA+4rKr4qYWOQD7qSgL8bv18Ec
++vGvPZ+JH2yqEA/h7qkCIQDBBP9vQnExv6Q1ewm6+0D/kWB7KBJfmPcZaH7WSbr8
+YwIgW05lBlVLubCC0ORHFTCkLO/3QgvqrXa0goiiLpRlUYkCIQCDTwsWfXTUCzOC
+znkIIvVM53FjVxdowX8YYeYnkXELUQIgTbecX8gqmq6bAjzNOTSq095q5qRVxcX/
+wARh6Zgnizk=
+-----END PRIVATE KEY-----`
+	k2crt := `-----BEGIN CERTIFICATE-----
+MIIB4TCCAYugAwIBAgIUXIs5A6R08x4nREVre0cngZJP+RQwDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMjA2MDgwNzQzMjNaFw0yMzA2
+MDgwNzQzMjNaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwXDANBgkqhkiG9w0BAQEF
+AANLADBIAkEAvaiL9hSWw/a7CmHDAXBfFn0Tx/Pm4YuwjJY0T/j+agTkKATVwN1J
+M+FRnVjtSXurztn4CMV8sM0ynTpUIxenWwIDAQABo1MwUTAdBgNVHQ4EFgQU92sq
+fqVvB3rLQR3/v9fmURv438YwHwYDVR0jBBgwFoAU92sqfqVvB3rLQR3/v9fmURv4
+38YwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAANBAHaF1we2MGmtd60u
+S8zLBpme53pJyY2r48Ol6xUSVLIoHOZ2V1TH0iHi4KnTMVyJwryyGZyhleAP7QA1
+d/hJs+A=
+-----END CERTIFICATE-----`
+
+	certFixture := `LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVFRENDQXZpZ0F3SUJBZ0lKQU5mK0lUMU1HaHhCTUEwR0NTcUdTSWI` +
+		`zRFFFQkN3VUFNSUdaTVFzd0NRWUQKVlFRR0V3SlZVekVMTUFrR0ExVUVDQXdDUTBFeEVqQVFCZ05WQkFjTUNWQmhiRzhnUVd4MGJ6RWlNQ0FHQ` +
+		`TFVRQpDZ3daVDI1bFEyOXVZMlZ5YmlCYmRHVnpkQ0J3ZFhKd2IzTmxYVEVjTUJvR0ExVUVBd3dUYjI1bFkyOXVZMlZ5CmJpMTBaWE4wTG1OdmJ` +
+		`URW5NQ1VHQ1NxR1NJYjNEUUVKQVJZWVpuSmxaR1Z5YVdOQVkyOXVaV052Ym1ObGNtNHUKWTI5dE1CNFhEVEU0TURnd016RTJNakUwT0ZvWERUR` +
+		`TVNVEl4TmpFMk1qRTBPRm93Z1lReEN6QUpCZ05WQkFZVApBbFZUTVFzd0NRWURWUVFJREFKRFFURVNNQkFHQTFVRUJ3d0pVR0ZzYnlCQmJIUnZ` +
+		`NU0l3SUFZRFZRUUxEQmxQCmJtVkRiMjVqWlhKdUlGdDBaWE4wSUhCMWNuQnZjMlZkTVRBd0xnWURWUVFERENkaGNHa3RjMlZ5ZG1salpTMXcKY` +
+		`205NGFXVmtMbTl1WldOdmJtTmxjbTR0ZEdWemRDNWpiMjB3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQgpEd0F3Z2dFS0FvSUJBUURXVzF` +
+		`KQnZweC9vZkYwei80QnkrYmdBcCtoYnlxblVsQ2FnYmlneE9QTHY3aUg4TSt1CjNENkRlSVkzQzdkV0thTjRnYXZHd1MvN3I0UWxXSWdvK09NR` +
+		`HQ1M25OZDVvakwvNWY5R1E0ZGRObW53b25EeEYKVThrd1lMWURMTkJIQzJqMzFBNVNueHo0S1NkVE03Rmc0OFBJeTNBaWFGMkhEcURZVlJpWkV` +
+		`ackl4U3JTSmFKZgp1WGVCSUVBcFBpUG1IOURObGw2VVo3ODZvZitJWWVLV2VuY0MvbGpPaGlJSnJWL3NEZTc2QVFjdXY5T29XaUdiCklGVFMyW` +
+		`ExSRGF0YzByQXhWdlFiTnMzeWlFYjh3UzBaR0F4cTBuZk9pMGZkYVBIODdFc25MdkpqWk5PcXIvTVMKSW5BYmN2ZmlwckxxaEdLQTVIN2hKVGZ` +
+		`EcFJ6WWxBcm5maTJMQWdNQkFBR2piakJzTUFrR0ExVWRFd1FDTUFBdwpDd1lEVlIwUEJBUURBZ1hnTUZJR0ExVWRFUVJMTUVtQ0htOWhkR2hyW` +
+		`ldWd1pYSXViMjVsWTI5dVkyVnliaTEwClpYTjBMbU52YllJbllYQnBMWE5sY25acFkyVXRjSEp2ZUdsbFpDNXZibVZqYjI1alpYSnVMWFJsYzN` +
+		`RdVkyOXQKTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCMVBibCtSbW50RW9jbHlqWXpzeWtLb2lYczNwYTgzQ2dEWjZwQwpncnY0TFF4U29FZ` +
+		`kowNGY4YkQ0SUlZRkdDWmZWTkcwVnBFWHJObGs2VWJzVmRUQUJ0cUNndUpUV3dER1VBaDZYCjNiRmhyWm5QZXhzLy9Rd2dEQWRxSWYwRWd3Y0R` +
+		`VRzc2R0lkZms3MGUxWnV4Y2h4ZDhVQkNwQUlkZVUwOHZWa3kKNFBXdjJLNGFENEZqQ2hLeENONWtoTjUwRk1QY2FJK3hWZ2Q0N3RQaFZOOWxRa` +
+		`W9HRENoc1Q1dkFSazdiYS9jZQowUTlOV2RpTWZMRWdMZGNCb2JaS0Z0RnJsS3R5ek9nRGpMdlh2TFFzL3MybWVyU0k5Zmt3b09CRVArN2o3Wm5` +
+		`zCkFqeTlNZmh3cWJUcFc3S3BDU0ZhMFZULzJ1OTVaUmNQdnJYbGRLUnlnQjRXdUFScgotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==`
+	keyFixture := `LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBMWx0U1FiNmNmNkh4ZE0vK0Fjdm00QUtm` +
+		`b1c4cXAxSlFtb0c0b01Uank3KzRoL0RQCnJ0dytnM2lHTnd1M1ZpbWplSUdyeHNFdis2K0VKVmlJS1BqakE3ZWQ1elhlYUl5LytYL1JrT0hYVF` +
+		`pwOEtKdzgKUlZQSk1HQzJBeXpRUnd0bzk5UU9VcDhjK0NrblV6T3hZT1BEeU10d0ltaGRodzZnMkZVWW1SR2F5TVVxMGlXaQpYN2wzZ1NCQUtU` +
+		`NGo1aC9RelpaZWxHZS9PcUgvaUdIaWxucDNBdjVZem9ZaUNhMWY3QTN1K2dFSExyL1RxRm9oCm15QlUwdGx5MFEyclhOS3dNVmIwR3piTjhvaE` +
+		`cvTUV0R1JnTWF0SjN6b3RIM1dqeC9PeExKeTd5WTJUVHFxL3oKRWlKd0czTDM0cWF5Nm9SaWdPUis0U1UzdzZVYzJKUUs1MzR0aXdJREFRQUJB` +
+		`b0lCQVFET2xyRE9RQ0NnT2JsMQo5VWMrLy84QkFrWksxZExyODc5UFNacGhCNkRycTFqeld6a3RzNEprUHZKTGR2VTVDMlJMTGQ0WjdmS0t4UH` +
+		`U4CjZuZy8xSzhsMC85UTZHL3puME1kK1B4R2dBSjYvbHFPNFJTTlZGVGdWVFRXRm9pZEQvZ1ljYjFrRDRsaCtuZTIKRG1uemtWQU40MU90Tlp4` +
+		`K0g3RVJEZUpwRTdoenFSOEhodnhxZU82Z25CMXJkZ3JRSE9MV1lSdmM1cGd2QS9BTwpYcTBRVXIrQWlUcTR0UW5oYjhDbDhJK2lLRmF5ZzZvY0` +
+		`FnQXVCZkZBMnVBd29CL25LajZXTHlJVHV0NWE1VDBQCmxpbVJaYllGUTFyeHBJaVpUMmFja0NxUjN1Yk9qdVBGOCtJZHVWSmNXN05WcTFRSlls` +
+		`RkFrSnVhTnpaRDlNMGkKUCs3WTgvTGhBb0dCQVBEYTg2cU9pazZpamNaajJtKzFub3dycnJINjdCRzhqRzdIYzJCZzU1M2VXWHZnQ3Z6RQppMk` +
+		`xYU3J6VVV6SGN2aHFQRVZqV2RPbk1rVHkxK2VoZDRnV3FTZW9iUlFqcHAxYU40clA5dVcvOStZaHVoTlZWCnJ2QUh3ZHBTaTRlelovNEVERmxl` +
+		`YUd5dXNWSkcvU1lJM096bnVQU051NW1lcysxN05Hb2pBZWtaQW9HQkFPUFYKMG5oRy9rNitQLzdlRXlqL2tjU3lPeUE5MzYvV05yVUU3bDF4b2` +
+		`YyK3laSVVhUitOcE1manpmcVJqaitRWmZIZwpJS0kvYmJGWGtlWm9nWG5seHk0T1YvSmtKZy9oTHo2alJUQjhYTW9kbEhwVnFOaEZYcWJhV1Bj` +
+		`a0h3WkhaVFU0CkNsQWg0QWZrZ2hpVWVrS2lhcTFNMWNyOE5CTWlyeTR2WWhKVXVReERBb0dCQUpyTG5aOFlUVHVNcmFHN3V6L2cKY2kyVVJZcU` +
+		`53ZnNFT3gxWGdvZUd3RlZ0K2dUclVTUnpEVUpSSysrQVpwZTlUMUN5Y211dUtTVzZHLzN3MXRUSQp3ZUx5TnQ4Rzk2OXF1K21jOXY3SEtzOFhZ` +
+		`N0NUbHp1ay9mRzJpcGhPUk83S0Z5UGlaaTFweDZOU0F4VG1HdnkrCjVYNDh6MW9kWFZ5MTZ0M09PVG1kbGpUQkFvR0FTYk5SY2pjRTdOUCtQNl` +
+		`AyN3J3OW16Tk1qUkYyMnBxZzk4MncKamVuRVRTRDZjNWJHcXI1WEg1SkJmMXkyZHpsdXdOK1BydXgxdjNoa2FmUkViZm8yaEY5L2M1bVI5bkVS` +
+		`cDJHSgpjRFhLamxjalFLK1UvdUR4eldlMGY3M2ZpMWh0Rk5vYisrLzVXSlJDd1ZER2UrZXVPb0V3WjRsT0R5S1pLSWVMCllnS21HYUVDZ1lBMF` +
+		`prd3k5ejFXczRBTmpHK1lsYVV4cEtMY0pGZHlDSEtkRnI2NVdZc21HcU5rSmZHU0dlQjYKUkhNWk5Nb0RUUmhtaFFoajhNN04rRk10WkFVT01k` +
+		`ZFovMWN2UkV0Rlc3KzY2dytYWnZqOUNRL3VlY3RwL3FiKwo2ZG5PYnJkbUxpWitVL056R0xLbUZnSlRjOVg3ZndtMTFQU2xpWkswV3JkblhLbn` +
+		`praDlPaFE9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=`
+
+	writeKeyToDiskDirs := func(t *testing.T, crt, key, dirCrt, dirKey string) (crtPath, keyPath string) {
+		crtPath = filepath.Join(dirCrt, "tls.crt")
+		keyPath = filepath.Join(dirKey, "tls.key")
+
+		require.NoError(t, ioutil.WriteFile(crtPath, []byte(crt), 0600))
+		require.NoError(t, ioutil.WriteFile(keyPath, []byte(key), 0600))
+		return
+	}
+
+	writeKeyToDisk := func(t *testing.T, crt, key, dirName string) (crtPath, keyPath string) {
+		return writeKeyToDiskDirs(t, crt, key, dirName, dirName)
+	}
+
+	t.Run("case=ensure generate is called if empty load", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ev := make(EventChannel, 1)
+
+		called := false
+		err := errors.New("test")
+		gen := CertificateGenerator(func() ([]tls.Certificate, error) {
+			called = true
+			return nil, err
+		})
+
+		p := NewProvider(ctx, ev)
+		p.SetCertificatesGenerator(gen)
+
+		require.Equal(t, err, p.LoadCertificates("", "", "", ""))
+		assert.Equal(t, true, called)
+	})
+
+	t.Run("case=load certificate from files", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ev := make(EventChannel, 1)
+
+		dir, err := os.MkdirTemp(t.TempDir(), "test")
+		require.NoError(t, err)
+
+		crtPath, keyPath := writeKeyToDisk(t, k1crt, k1priv, dir)
+
+		p := NewProvider(ctx, ev)
+
+		require.NoError(t, p.LoadCertificates("", "", crtPath, keyPath))
+
+		c, err := p.GetCertificate(nil)
+		require.NoError(t, err)
+		assert.NotEqual(t, nil, c)
+
+		crtPath, keyPath = writeKeyToDisk(t, k2crt, k2priv, dir)
+		assert.Equal(t, &ChangeEvent{}, <-ev)
+		assert.Equal(t, &ChangeEvent{}, <-ev)
+
+		c2, err := p.GetCertificate(nil)
+		require.NoError(t, err)
+		assert.NotEqual(t, nil, c2)
+
+		assert.NotEqual(t, 0, bytes.Compare(c.Certificate[0], c2.Certificate[0]))
+	})
+
+	t.Run("case=load certificate from files in two folders", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ev := make(EventChannel, 1)
+
+		dir1, err := os.MkdirTemp(t.TempDir(), "test")
+		require.NoError(t, err)
+
+		dir2, err := os.MkdirTemp(t.TempDir(), "test")
+		require.NoError(t, err)
+
+		crtPath, keyPath := writeKeyToDiskDirs(t, k1crt, k1priv, dir1, dir2)
+
+		p := NewProvider(ctx, ev)
+
+		require.NoError(t, p.LoadCertificates("", "", crtPath, keyPath))
+
+		c, err := p.GetCertificate(nil)
+		require.NoError(t, err)
+		assert.NotEqual(t, nil, c)
+
+		crtPath, keyPath = writeKeyToDiskDirs(t, k2crt, k2priv, dir1, dir2)
+		assert.Equal(t, &ChangeEvent{}, <-ev)
+		assert.Equal(t, &ChangeEvent{}, <-ev)
+
+		c2, err := p.GetCertificate(nil)
+		require.NoError(t, err)
+		assert.NotEqual(t, nil, c2)
+
+		assert.NotEqual(t, 0, bytes.Compare(c.Certificate[0], c2.Certificate[0]))
+	})
+
+	t.Run("case=load certificate base64", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ev := make(EventChannel, 1)
+
+		p := NewProvider(ctx, ev)
+
+		require.NoError(t, p.LoadCertificates(certFixture, keyFixture, "", ""))
+
+		c, err := p.GetCertificate(nil)
+		require.NoError(t, err)
+		assert.NotEqual(t, nil, c)
+		assert.Equal(t, 0, len(ev))
+	})
+
+	t.Run("case=load certificate from files then base64 then files", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ev := make(EventChannel, 1)
+
+		dir, err := os.MkdirTemp(t.TempDir(), "test")
+		require.NoError(t, err)
+
+		crtPath, keyPath := writeKeyToDisk(t, k1crt, k1priv, dir)
+
+		p := NewProvider(ctx, ev)
+
+		require.NoError(t, p.LoadCertificates("", "", crtPath, keyPath))
+
+		c, err := p.GetCertificate(nil)
+		require.NoError(t, err)
+		assert.NotEqual(t, nil, c)
+
+		require.NoError(t, p.LoadCertificates(certFixture, keyFixture, "", ""))
+
+		c2, err := p.GetCertificate(nil)
+		require.NoError(t, err)
+		assert.NotEqual(t, nil, c2)
+		assert.NotEqual(t, 0, bytes.Compare(c.Certificate[0], c2.Certificate[0]))
+
+		require.NoError(t, p.LoadCertificates("", "", crtPath, keyPath))
+
+		c3, err := p.GetCertificate(nil)
+		require.NoError(t, err)
+		assert.NotEqual(t, nil, c3)
+		assert.Equal(t, 0, bytes.Compare(c.Certificate[0], c3.Certificate[0]))
+	})
+}

--- a/tlsx/cert_provider_test.go
+++ b/tlsx/cert_provider_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -185,7 +184,6 @@ d/hJs+A=
 		assert.NotEqual(t, nil, c)
 
 		writeKeyToDiskDirs(t, k2crt, k2priv, dir1, dir2)
-		time.Sleep(2 * time.Second)
 		assert.Equal(t, &ChangeEvent{}, <-ev)
 
 		c2, err := p.GetCertificate(nil)

--- a/tlsx/cert_provider_test.go
+++ b/tlsx/cert_provider_test.go
@@ -1,0 +1,144 @@
+package tlsx
+
+// func TestCertProvider(t *testing.T) {
+// 	tmpDir, err := ioutil.TempDir(os.TempDir(), "test_cert_provider")
+// 	require.NoError(t, err)
+//
+// 	defer os.RemoveAll(tmpDir)
+//
+// 	logger := logrusx.New("", "")
+// 	cert1Data := []byte("cert1")
+// 	cert1 := tls.Certificate{Certificate: [][]byte{cert1Data}}
+// 	cert2Data := []byte("cert2")
+// 	cert2 := tls.Certificate{Certificate: [][]byte{cert2Data}}
+//
+// 	certLoad := CertLoadFunc(func() ([]tls.Certificate, error) {
+// 		return []tls.Certificate{cert2}, nil
+// 	})
+//
+// 	crtLoc := CertLocation{
+// 		KeyPath:  path.Join(tmpDir, "tls.key"),
+// 		CertPath: path.Join(tmpDir, "tls.crt"),
+// 	}
+// 	provider := NewCertProvider(
+// 		[]tls.Certificate{cert1},
+// 		crtLoc,
+// 		certLoad,
+// 		logger,
+// 	)
+// 	defer provider.Stop()
+//
+// 	//Checking initial cert load
+// 	cert, err := provider.GetCertificate(nil)
+// 	require.NoError(t, err)
+// 	assert.Equal(t, cert1Data, cert.Certificate[0])
+//
+// 	//Touching tls.key to trigger fs change
+// 	_, err = os.Create(crtLoc.KeyPath)
+// 	require.NoError(t, err)
+//
+// 	//The first tls.Certificate should stay before the reloading process
+// 	cert, err = provider.GetCertificate(nil)
+// 	require.NoError(t, err)
+// 	assert.Equal(t, cert1Data, cert.Certificate[0])
+//
+// 	//New cert should be loaded
+// 	time.Sleep(3 * time.Second)
+// 	cert, err = provider.GetCertificate(nil)
+// 	require.NoError(t, err)
+// 	assert.Equal(t, cert2Data, cert.Certificate[0])
+// }
+//
+// func TestCertProviderDualDir(t *testing.T) {
+// 	tmpDir, err := ioutil.TempDir(os.TempDir(), "test_cert_provider")
+// 	require.NoError(t, err)
+// 	defer os.RemoveAll(tmpDir)
+//
+// 	tmpDir2, err := ioutil.TempDir(os.TempDir(), "test_cert_provider")
+// 	require.NoError(t, err)
+// 	defer os.RemoveAll(tmpDir2)
+//
+// 	logger := logrusx.New("", "")
+// 	cert1Data := []byte("cert1")
+// 	cert1 := tls.Certificate{Certificate: [][]byte{cert1Data}}
+// 	cert2Data := []byte("cert2")
+// 	cert2 := tls.Certificate{Certificate: [][]byte{cert2Data}}
+//
+// 	certLoad := CertLoadFunc(func() ([]tls.Certificate, error) {
+// 		return []tls.Certificate{cert2}, nil
+// 	})
+//
+// 	crtLoc := CertLocation{
+// 		KeyPath:  path.Join(tmpDir, "tls.key"),
+// 		CertPath: path.Join(tmpDir2, "tls.crt"),
+// 	}
+// 	provider := NewCertProvider(
+// 		[]tls.Certificate{cert1},
+// 		crtLoc,
+// 		certLoad,
+// 		logger,
+// 	)
+// 	defer provider.Stop()
+//
+// 	//Checking initial cert load
+// 	cert, err := provider.GetCertificate(nil)
+// 	require.NoError(t, err)
+// 	assert.Equal(t, cert1Data, cert.Certificate[0])
+//
+// 	//Touching tls.crt to trigger fs change
+// 	_, err = os.Create(crtLoc.CertPath)
+// 	require.NoError(t, err)
+//
+// 	//The first tls.Certificate should stay before the reloading process
+// 	cert, err = provider.GetCertificate(nil)
+// 	require.NoError(t, err)
+// 	assert.Equal(t, cert1Data, cert.Certificate[0])
+//
+// 	//New cert should be loaded
+// 	time.Sleep(3 * time.Second)
+// 	cert, err = provider.GetCertificate(nil)
+// 	require.NoError(t, err)
+// 	assert.Equal(t, cert2Data, cert.Certificate[0])
+// }
+//
+// func TestCertProviderErrorReload(t *testing.T) {
+// 	tmpDir, err := ioutil.TempDir(os.TempDir(), "test_cert_provider")
+// 	require.NoError(t, err)
+//
+// 	defer os.RemoveAll(tmpDir)
+//
+// 	logger := logrusx.New("", "")
+// 	cert1Data := []byte("cert1")
+// 	cert1 := tls.Certificate{Certificate: [][]byte{cert1Data}}
+//
+// 	certLoad := CertLoadFunc(func() ([]tls.Certificate, error) {
+// 		return nil, errors.New("Test error")
+// 	})
+//
+// 	crtLoc := CertLocation{
+// 		KeyPath:  path.Join(tmpDir, "tls.key"),
+// 		CertPath: path.Join(tmpDir, "tls.crt"),
+// 	}
+// 	provider := NewCertProvider(
+// 		[]tls.Certificate{cert1},
+// 		crtLoc,
+// 		certLoad,
+// 		logger,
+// 	)
+// 	defer provider.Stop()
+//
+// 	//Checking initial cert load
+// 	cert, err := provider.GetCertificate(nil)
+// 	require.NoError(t, err)
+// 	assert.Equal(t, cert1Data, cert.Certificate[0])
+//
+// 	//Touching tls.key to trigger fs change
+// 	_, err = os.Create(crtLoc.KeyPath)
+// 	require.NoError(t, err)
+//
+// 	//Old cert should stay
+// 	time.Sleep(3 * time.Second)
+// 	cert, err = provider.GetCertificate(nil)
+// 	require.NoError(t, err)
+// 	assert.Equal(t, cert1Data, cert.Certificate[0])
+// }

--- a/tlsx/cert_provider_test.go
+++ b/tlsx/cert_provider_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -147,13 +148,13 @@ d/hJs+A=
 		p := NewProvider(ctx, ev)
 
 		require.NoError(t, p.LoadCertificates("", "", crtPath, keyPath))
+		require.NoError(t, p.LoadCertificates("", "", crtPath, keyPath)) // Loading twice to test watcher change
 
 		c, err := p.GetCertificate(nil)
 		require.NoError(t, err)
 		assert.NotEqual(t, nil, c)
 
-		crtPath, keyPath = writeKeyToDisk(t, k2crt, k2priv, dir)
-		assert.Equal(t, &ChangeEvent{}, <-ev)
+		writeKeyToDisk(t, k2crt, k2priv, dir)
 		assert.Equal(t, &ChangeEvent{}, <-ev)
 
 		c2, err := p.GetCertificate(nil)
@@ -179,13 +180,14 @@ d/hJs+A=
 		p := NewProvider(ctx, ev)
 
 		require.NoError(t, p.LoadCertificates("", "", crtPath, keyPath))
+		require.NoError(t, p.LoadCertificates("", "", crtPath, keyPath)) // Loading twice to test watcher change
 
 		c, err := p.GetCertificate(nil)
 		require.NoError(t, err)
 		assert.NotEqual(t, nil, c)
 
-		crtPath, keyPath = writeKeyToDiskDirs(t, k2crt, k2priv, dir1, dir2)
-		assert.Equal(t, &ChangeEvent{}, <-ev)
+		writeKeyToDiskDirs(t, k2crt, k2priv, dir1, dir2)
+		time.Sleep(2 * time.Second)
 		assert.Equal(t, &ChangeEvent{}, <-ev)
 
 		c2, err := p.GetCertificate(nil)


### PR DESCRIPTION
Kubernetes is able to auto-renew certificates with cert-manager and update files in the container. It would be cool if Ory Hydra /Kratos could support auto certificate update on file change.

---

As discussed in Ory Hydra / Kratos, core components should be merged in X repo.