### PR TITLE
feat(otelx): ignore admin health endpoint

### DIFF
--- a/otelx/middleware.go
+++ b/otelx/middleware.go
@@ -17,9 +17,18 @@ func isHealthFilter(r *http.Request) bool {
 	return true
 }
 
+func isAdminHealthFilter(r *http.Request) bool {
+	path := r.URL.Path
+	if strings.HasPrefix(path, "/admin/health/") {
+		return false
+	}
+	return true
+}
+
 func filterOpts() []otelhttp.Option {
 	filters := []otelhttp.Filter{
 		isHealthFilter,
+		isAdminHealthFilter,
 	}
 	opts := []otelhttp.Option{}
 	for _, f := range filters {

--- a/otelx/middleware_test.go
+++ b/otelx/middleware_test.go
@@ -23,6 +23,10 @@ func TestShouldNotTraceHealthEndpoint(t *testing.T) {
 			testDescription: "health",
 		},
 		{
+			path:            "admin/alive",
+			testDescription: "adminHealth",
+		},
+		{
 			path:            "foo/bar",
 			testDescription: "notHealth",
 		},


### PR DESCRIPTION
The `/admin/health/{alive,ready}` paths get traced in Kratos; this patch adds a filter rule for it.