### PR TITLE
refactor: API changes for healthx for middleware

### DIFF
--- a/healthx/handler_test.go
+++ b/healthx/handler_test.go
@@ -36,73 +36,10 @@ import (
 	"github.com/ory/herodot"
 )
 
-const mockHeaderKey = "middleware-header"
-const mockHeaderValue = "test-header-value"
-
-func coreHealthTests(t *testing.T, handler *Handler, router *httprouter.Router, withMiddleware bool) {
-
-	alive := errors.New("not alive")
-
-	handler.ReadyChecks = map[string]ReadyChecker{
-		"test": func(r *http.Request) error {
-			return alive
-		},
-	}
-
-	// helper to run the same assertion on various responses that are with the middleware,
-	// avoid having to write the same if condition and assertion again
-	assertMockHeader := func(t *testing.T, res *http.Response, withMiddleware bool) {
-		if withMiddleware == false {
-			return
-		}
-		assert.EqualValues(t, mockHeaderValue, res.Header.Get(mockHeaderKey))
-	}
-
-	ts := httptest.NewServer(router)
-
-	c := http.DefaultClient
-
-	var healthBody swaggerHealthStatus
-	response, err := c.Get(ts.URL + AliveCheckPath)
-	require.NoError(t, err)
-	require.EqualValues(t, http.StatusOK, response.StatusCode)
-	require.NoError(t, json.NewDecoder(response.Body).Decode(&healthBody))
-	assert.EqualValues(t, "ok", healthBody.Status)
-	assertMockHeader(t, response, withMiddleware)
-
-	var versionBody swaggerVersion
-	response, err = c.Get(ts.URL + VersionPath)
-	require.NoError(t, err)
-	require.EqualValues(t, http.StatusOK, response.StatusCode)
-	require.NoError(t, json.NewDecoder(response.Body).Decode(&versionBody))
-	require.EqualValues(t, versionBody.Version, handler.VersionString)
-	assertMockHeader(t, response, withMiddleware)
-
-	response, err = c.Get(ts.URL + ReadyCheckPath)
-	require.NoError(t, err)
-	require.EqualValues(t, http.StatusServiceUnavailable, response.StatusCode)
-	out, err := ioutil.ReadAll(response.Body)
-	require.NoError(t, err)
-	assert.EqualValues(t, "ok", healthBody.Status)
-	assert.Equal(t, `{"errors":{"test":"not alive"}}`, strings.TrimSpace(string(out)))
-	assertMockHeader(t, response, withMiddleware)
-
-	alive = nil
-	response, err = c.Get(ts.URL + ReadyCheckPath)
-	require.NoError(t, err)
-	require.EqualValues(t, http.StatusOK, response.StatusCode)
-	require.NoError(t, json.NewDecoder(response.Body).Decode(&versionBody))
-	require.EqualValues(t, versionBody.Version, handler.VersionString)
-	assertMockHeader(t, response, withMiddleware)
-
-}
-
 func TestHealth(t *testing.T) {
-
-	handler := &Handler{
-		H:             herodot.NewJSONWriter(nil),
-		VersionString: "test version",
-	}
+	const mockHeaderKey = "middleware-header"
+	const mockHeaderValue = "test-header-value"
+	const mockVersion = "test version"
 
 	// middlware to run an assert function on the requested handler
 	testMiddleware := func(t *testing.T, assertFunc func(*testing.T, http.ResponseWriter, *http.Request)) func(next http.Handler) http.Handler {
@@ -115,18 +52,140 @@ func TestHealth(t *testing.T) {
 		}
 	}
 
-	t.Run("case:without middleware", func(t *testing.T) {
+	assertAliveCheck := func(t *testing.T, endpoint string, handler *Handler) *http.Response {
+		var healthBody swaggerHealthStatus
+		c := http.DefaultClient
+		response, err := c.Get(endpoint)
+		require.NoError(t, err)
+		require.EqualValues(t, http.StatusOK, response.StatusCode)
+		require.NoError(t, json.NewDecoder(response.Body).Decode(&healthBody))
+		assert.EqualValues(t, "ok", healthBody.Status)
+		return response
+	}
+
+	assertVersionResponse := func(t *testing.T, endpoint string, handler *Handler) *http.Response {
+		var versionBody swaggerVersion
+		c := http.DefaultClient
+		response, err := c.Get(endpoint)
+		require.NoError(t, err)
+		require.EqualValues(t, http.StatusOK, response.StatusCode)
+		require.NoError(t, json.NewDecoder(response.Body).Decode(&versionBody))
+		require.EqualValues(t, mockVersion, versionBody.Version)
+		return response
+	}
+
+	assertReadyCheckNotAlive := func(t *testing.T, endpoint string, handler *Handler) *http.Response {
+		handler.ReadyChecks = map[string]ReadyChecker{
+			"test": func(r *http.Request) error {
+				return errors.New("not alive")
+			},
+		}
+		c := http.DefaultClient
+		response, err := c.Get(endpoint)
+		require.NoError(t, err)
+		require.EqualValues(t, http.StatusServiceUnavailable, response.StatusCode)
+		out, err := ioutil.ReadAll(response.Body)
+		require.NoError(t, err)
+		assert.Equal(t, `{"errors":{"test":"not alive"}}`, strings.TrimSpace(string(out)))
+		return response
+	}
+
+	assertReadyCheck := func(t *testing.T, endpoint string, handler *Handler) *http.Response {
+		handler.ReadyChecks = map[string]ReadyChecker{
+			"test": func(r *http.Request) error {
+				return nil
+			},
+		}
+		var healthCheck swaggerHealthStatus
+		c := http.DefaultClient
+		response, err := c.Get(endpoint)
+		require.NoError(t, err)
+		require.EqualValues(t, http.StatusOK, response.StatusCode)
+		require.NoError(t, json.NewDecoder(response.Body).Decode(&healthCheck))
+		require.EqualValues(t, swaggerHealthStatus{Status: "ok"}, healthCheck)
+		return response
+	}
+
+	testCases := []struct {
+		description string
+		url         func(mockServerURL string) string
+		test        func(t *testing.T, endpoint string, handler *Handler) *http.Response
+	}{
+		{
+			description: "ready check should return status ok",
+			url: func(mockServerURL string) string {
+				return mockServerURL + ReadyCheckPath
+			},
+			test: assertReadyCheck,
+		},
+		{
+			description: "ready check should return error",
+			url: func(mockServerURL string) string {
+				return mockServerURL + ReadyCheckPath
+			},
+			test: assertReadyCheckNotAlive,
+		},
+		{
+			description: "alive check should return status ok",
+			url: func(mockServerURL string) string {
+				return mockServerURL + AliveCheckPath
+			},
+			test: assertAliveCheck,
+		},
+		{
+			description: "version should return",
+			url: func(mockServerURL string) string {
+				return mockServerURL + VersionPath
+			},
+			test: assertVersionResponse,
+		},
+	}
+
+	t.Run("case=without middleware", func(t *testing.T) {
 		router := httprouter.New()
+
+		handler := &Handler{
+			H:             herodot.NewJSONWriter(nil),
+			VersionString: mockVersion,
+			ReadyChecks: map[string]ReadyChecker{
+				"test": func(r *http.Request) error {
+					return nil
+				},
+			},
+		}
+
+		ts := httptest.NewServer(router)
+		defer ts.Close()
 
 		handler.SetHealthRoutes(router, true)
 		handler.SetVersionRoutes(router)
 
-		coreHealthTests(t, handler, router, false)
+		for _, tc := range testCases {
+			t.Run("case="+tc.description, func(t *testing.T) {
+				tc.test(t, tc.url(ts.URL), handler)
+			})
+		}
 	})
 
-	t.Run("case:with middleware", func(t *testing.T) {
+	t.Run("case=with middleware", func(t *testing.T) {
 		router := httprouter.New()
 
+		var alive error
+
+		handler := &Handler{
+			H:             herodot.NewJSONWriter(nil),
+			VersionString: mockVersion,
+			ReadyChecks: map[string]ReadyChecker{
+				"test": func(r *http.Request) error {
+					return alive
+				},
+			},
+		}
+
+		ts := httptest.NewServer(router)
+		defer ts.Close()
+
+		// set the health handlers with middleware
 		handler.SetHealthRoutes(router, true, WithMiddleware(
 			testMiddleware(t, func(t *testing.T, rw http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "GET", r.Method)
@@ -139,6 +198,11 @@ func TestHealth(t *testing.T) {
 			}),
 		))
 
-		coreHealthTests(t, handler, router, true)
+		for _, tc := range testCases {
+			t.Run("case="+tc.description, func(t *testing.T) {
+				response := tc.test(t, tc.url(ts.URL), handler)
+				assert.EqualValues(t, mockHeaderValue, response.Header.Get(mockHeaderKey))
+			})
+		}
 	})
 }

--- a/healthx/handler_test.go
+++ b/healthx/handler_test.go
@@ -40,73 +40,129 @@ const mockHeaderKey = "middleware-header"
 const mockHeaderValue = "test-header-value"
 
 func TestHealth(t *testing.T) {
-	alive := errors.New("not alive")
-	handler := &Handler{
-		H:             herodot.NewJSONWriter(nil),
-		VersionString: "test version",
-		ReadyChecks: map[string]ReadyChecker{
-			"test": func(r *http.Request) error {
-				return alive
+	t.Run("case:without middleware", func(t *testing.T) {
+		// separate set of `handler` and `alive` as the `alive` would need to be reset after the last test in the above
+		alive := errors.New("not alive")
+		handler := &Handler{
+			H:             herodot.NewJSONWriter(nil),
+			VersionString: "test version",
+			ReadyChecks: map[string]ReadyChecker{
+				"test": func(r *http.Request) error {
+					return alive
+				},
 			},
-		},
-	}
-
-	// middleware to assert and test before the request is completed
-	testMiddleware := func(t *testing.T, assertFunc func(*testing.T, http.ResponseWriter, *http.Request)) func(next http.Handler) http.Handler {
-		return func(h http.Handler) http.Handler {
-			return http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
-				writer.Header().Add(mockHeaderKey, mockHeaderValue)
-				assertFunc(t, writer, req)
-				h.ServeHTTP(writer, req)
-			})
 		}
-	}
 
-	router := httprouter.New()
+		router := httprouter.New()
 
-	handler.SetHealthRoutes(router, true,
-		WithMiddleware(testMiddleware(t, func(t *testing.T, rw http.ResponseWriter, r *http.Request) {
+		handler.SetHealthRoutes(router, true)
+		handler.SetVersionRoutes(router)
+
+		ts := httptest.NewServer(router)
+
+		c := http.DefaultClient
+
+		var healthBody swaggerHealthStatus
+		response, err := c.Get(ts.URL + AliveCheckPath)
+		require.NoError(t, err)
+		require.EqualValues(t, http.StatusOK, response.StatusCode)
+		require.NoError(t, json.NewDecoder(response.Body).Decode(&healthBody))
+		assert.EqualValues(t, "ok", healthBody.Status)
+
+		var versionBody swaggerVersion
+		response, err = c.Get(ts.URL + VersionPath)
+		require.NoError(t, err)
+		require.EqualValues(t, http.StatusOK, response.StatusCode)
+		require.NoError(t, json.NewDecoder(response.Body).Decode(&versionBody))
+		require.EqualValues(t, versionBody.Version, handler.VersionString)
+
+		response, err = c.Get(ts.URL + ReadyCheckPath)
+		require.NoError(t, err)
+		require.EqualValues(t, http.StatusServiceUnavailable, response.StatusCode)
+		out, err := ioutil.ReadAll(response.Body)
+		require.NoError(t, err)
+		assert.EqualValues(t, "ok", healthBody.Status)
+		assert.Equal(t, `{"errors":{"test":"not alive"}}`, strings.TrimSpace(string(out)))
+
+		alive = nil
+		response, err = c.Get(ts.URL + ReadyCheckPath)
+		require.NoError(t, err)
+		require.EqualValues(t, http.StatusOK, response.StatusCode)
+		require.NoError(t, json.NewDecoder(response.Body).Decode(&versionBody))
+		require.EqualValues(t, versionBody.Version, handler.VersionString)
+
+	})
+
+	t.Run("case:with middleware", func(t *testing.T) {
+		// separate set of `handler` and `alive` as the `alive` would need to be reset after the last test in the above
+		alive := errors.New("not alive")
+		handler := &Handler{
+			H:             herodot.NewJSONWriter(nil),
+			VersionString: "test version",
+			ReadyChecks: map[string]ReadyChecker{
+				"test": func(r *http.Request) error {
+					return alive
+				},
+			},
+		}
+
+		// middleware to assert and test before the request is completed
+		testMiddleware := func(t *testing.T, assertFunc func(*testing.T, http.ResponseWriter, *http.Request)) func(next http.Handler) http.Handler {
+			return func(h http.Handler) http.Handler {
+				return http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+					writer.Header().Add(mockHeaderKey, mockHeaderValue)
+					assertFunc(t, writer, req)
+					h.ServeHTTP(writer, req)
+				})
+			}
+		}
+
+		router := httprouter.New()
+
+		handler.SetHealthRoutes(router, true,
+			WithMiddleware(testMiddleware(t, func(t *testing.T, rw http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "GET", r.Method)
+			})),
+		)
+
+		handler.SetVersionRoutes(router, WithMiddleware(testMiddleware(t, func(t *testing.T, rw http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "GET", r.Method)
-		})),
-	)
+		})))
 
-	handler.SetVersionRoutes(router, WithMiddleware(testMiddleware(t, func(t *testing.T, rw http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "GET", r.Method)
-	})))
+		ts := httptest.NewServer(router)
+		c := http.DefaultClient
 
-	ts := httptest.NewServer(router)
-	c := http.DefaultClient
+		var healthBody swaggerHealthStatus
+		response, err := c.Get(ts.URL + AliveCheckPath)
+		require.NoError(t, err)
+		require.EqualValues(t, http.StatusOK, response.StatusCode)
+		require.NoError(t, json.NewDecoder(response.Body).Decode(&healthBody))
+		assert.EqualValues(t, "ok", healthBody.Status)
+		assert.EqualValues(t, mockHeaderValue, response.Header.Get(mockHeaderKey))
 
-	var healthBody swaggerHealthStatus
-	response, err := c.Get(ts.URL + AliveCheckPath)
-	require.NoError(t, err)
-	require.EqualValues(t, http.StatusOK, response.StatusCode)
-	require.NoError(t, json.NewDecoder(response.Body).Decode(&healthBody))
-	assert.EqualValues(t, "ok", healthBody.Status)
-	assert.EqualValues(t, mockHeaderValue, response.Header.Get(mockHeaderKey))
+		var versionBody swaggerVersion
+		response, err = c.Get(ts.URL + VersionPath)
+		require.NoError(t, err)
+		require.EqualValues(t, http.StatusOK, response.StatusCode)
+		require.NoError(t, json.NewDecoder(response.Body).Decode(&versionBody))
+		require.EqualValues(t, versionBody.Version, handler.VersionString)
+		assert.EqualValues(t, mockHeaderValue, response.Header.Get(mockHeaderKey))
 
-	var versionBody swaggerVersion
-	response, err = c.Get(ts.URL + VersionPath)
-	require.NoError(t, err)
-	require.EqualValues(t, http.StatusOK, response.StatusCode)
-	require.NoError(t, json.NewDecoder(response.Body).Decode(&versionBody))
-	require.EqualValues(t, versionBody.Version, handler.VersionString)
-	assert.EqualValues(t, mockHeaderValue, response.Header.Get(mockHeaderKey))
+		response, err = c.Get(ts.URL + ReadyCheckPath)
+		require.NoError(t, err)
+		require.EqualValues(t, http.StatusServiceUnavailable, response.StatusCode)
+		out, err := ioutil.ReadAll(response.Body)
+		require.NoError(t, err)
+		assert.EqualValues(t, "ok", healthBody.Status)
+		assert.Equal(t, `{"errors":{"test":"not alive"}}`, strings.TrimSpace(string(out)))
+		assert.EqualValues(t, mockHeaderValue, response.Header.Get(mockHeaderKey))
 
-	response, err = c.Get(ts.URL + ReadyCheckPath)
-	require.NoError(t, err)
-	require.EqualValues(t, http.StatusServiceUnavailable, response.StatusCode)
-	out, err := ioutil.ReadAll(response.Body)
-	require.NoError(t, err)
-	assert.EqualValues(t, "ok", healthBody.Status)
-	assert.Equal(t, `{"errors":{"test":"not alive"}}`, strings.TrimSpace(string(out)))
-	assert.EqualValues(t, mockHeaderValue, response.Header.Get(mockHeaderKey))
-
-	alive = nil
-	response, err = c.Get(ts.URL + ReadyCheckPath)
-	require.NoError(t, err)
-	require.EqualValues(t, http.StatusOK, response.StatusCode)
-	require.NoError(t, json.NewDecoder(response.Body).Decode(&versionBody))
-	require.EqualValues(t, versionBody.Version, handler.VersionString)
-	assert.EqualValues(t, mockHeaderValue, response.Header.Get(mockHeaderKey))
+		alive = nil
+		response, err = c.Get(ts.URL + ReadyCheckPath)
+		require.NoError(t, err)
+		require.EqualValues(t, http.StatusOK, response.StatusCode)
+		require.NoError(t, json.NewDecoder(response.Body).Decode(&versionBody))
+		require.EqualValues(t, versionBody.Version, handler.VersionString)
+		assert.EqualValues(t, mockHeaderValue, response.Header.Get(mockHeaderKey))
+	})
 }

--- a/healthx/handler_test.go
+++ b/healthx/handler_test.go
@@ -39,12 +39,6 @@ import (
 const mockHeaderKey = "middleware-header"
 const mockHeaderValue = "test-header-value"
 
-func WithMiddleware(h func(http.Handler) http.Handler) func(*Options) {
-	return func(o *Options) {
-		o.Middleware = h
-	}
-}
-
 func TestHealth(t *testing.T) {
 	alive := errors.New("not alive")
 	handler := &Handler{

--- a/healthx/handler_test.go
+++ b/healthx/handler_test.go
@@ -91,11 +91,6 @@ func TestHealth(t *testing.T) {
 	}
 
 	assertReadyCheck := func(t *testing.T, endpoint string, handler *Handler) *http.Response {
-		handler.ReadyChecks = map[string]ReadyChecker{
-			"test": func(r *http.Request) error {
-				return nil
-			},
-		}
 		var healthCheck swaggerHealthStatus
 		c := http.DefaultClient
 		response, err := c.Get(endpoint)
@@ -200,6 +195,11 @@ func TestHealth(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run("case="+tc.description, func(t *testing.T) {
+				handler.ReadyChecks = map[string]ReadyChecker{
+					"test": func(r *http.Request) error {
+						return nil
+					},
+				}
 				response := tc.test(t, tc.url(ts.URL), handler)
 				assert.EqualValues(t, mockHeaderValue, response.Header.Get(mockHeaderKey))
 			})


### PR DESCRIPTION

**BREAKING CHANGES**: changes the API definitions of the following 
`healthx/Alive, healthx/Ready, healthx/Version, healthx/SetHealthRoutes,healthx/SetVersionRoutes`

will add support for passing a middleware to the register
function, also changes the actual handlers to return http.handlers
instead

## Related Issue or Design Document
lays the base set of changes for https://github.com/ory/hydra/pull/3114

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.(modified existing tests)
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

