### PR TITLE
Add http client cmdx helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ format:
 		goimports -w -local github.com/ory .
 
 .bin/golangci-lint: Makefile
-		bash <(curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh) -d -b .bin v1.44.2
+		bash <(curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh) -d -b .bin v1.46.2
 
 .PHONY: test
 test:

--- a/clidoc/generate.go
+++ b/clidoc/generate.go
@@ -38,16 +38,16 @@ func generate(cmd *cobra.Command, dir string) error {
 	}
 
 	basename := strings.Replace(cmd.CommandPath(), " ", "-", -1)
-	if err := os.MkdirAll(filepath.Join(dir), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(dir), 0750); err != nil {
 		return err
 	}
 
 	filename := filepath.Join(dir, basename) + ".md"
-	f, err := os.Create(filename)
+	f, err := os.Create(filename) //#nosec:G304
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer (func() { _ = f.Close() })()
 
 	if _, err := io.WriteString(f, fmt.Sprintf(`---
 id: %s

--- a/clidoc/md_docs.go
+++ b/clidoc/md_docs.go
@@ -137,11 +137,11 @@ func GenMarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHa
 
 	basename := strings.Replace(cmd.CommandPath(), " ", "_", -1) + ".md"
 	filename := filepath.Join(dir, basename)
-	f, err := os.Create(filename)
+	f, err := os.Create(filename) //#nosec:G304) //#nosec:G304
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer (func() { _ = f.Close() })()
 
 	if _, err := io.WriteString(f, filePrepender(filename)); err != nil {
 		return err

--- a/cmdx/http.go
+++ b/cmdx/http.go
@@ -106,8 +106,8 @@ func NewClient(cmd *cobra.Command) (*http.Client, *url.URL, error) {
 
 	rt := httpx.NewTransportWithHeader(header)
 	rt.RoundTripper = &http.Transport{
+		//#nosec G402 -- This is a false positive
 		TLSClientConfig: &tls.Config{
-			//#nosec G402 -- we want to support dev environments, hence tls trickery
 			InsecureSkipVerify: skipVerify,
 		},
 	}

--- a/cmdx/http.go
+++ b/cmdx/http.go
@@ -107,7 +107,7 @@ func NewClient(cmd *cobra.Command) (*http.Client, *url.URL, error) {
 	rt := httpx.NewTransportWithHeader(header)
 	rt.RoundTripper = &http.Transport{
 		TLSClientConfig: &tls.Config{
-			/* #nosec G402 - we want to support dev environments, hence tls trickery */
+			//#nosec G402 -- we want to support dev environments, hence tls trickery
 			InsecureSkipVerify: skipVerify,
 		},
 	}

--- a/cmdx/printing.go
+++ b/cmdx/printing.go
@@ -126,7 +126,7 @@ func PrintTable(cmd *cobra.Command, table Table) {
 			fmt.Fprintln(w, strings.Join(row, "\t")+"\t")
 		}
 
-		w.Flush()
+		_ = w.Flush()
 	}
 }
 

--- a/configx/koanf_file.go
+++ b/configx/koanf_file.go
@@ -59,6 +59,7 @@ func (f *KoanfFile) ReadBytes() ([]byte, error) {
 
 // Read is not supported by the file provider.
 func (f *KoanfFile) Read() (map[string]interface{}, error) {
+	//#nosec G304 -- false positive
 	fc, err := ioutil.ReadFile(f.path)
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/corsx/middleware.go
+++ b/corsx/middleware.go
@@ -1,0 +1,29 @@
+package corsx
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/rs/cors"
+	"github.com/urfave/negroni"
+)
+
+// ContextualizedMiddleware is a context-aware CORS middleware. It allows hot-reloading CORS configuration using
+// the HTTP request context.
+//
+//  n := negroni.New()
+//  n.UseFunc(ContextualizedMiddleware(func(context.Context) (opts cors.Options, enabled bool) {
+//    panic("implement me")
+//  })
+//  // ...
+func ContextualizedMiddleware(provider func(context.Context) (opts cors.Options, enabled bool)) negroni.HandlerFunc {
+	return func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+		options, enabled := provider(r.Context())
+		if !enabled {
+			next(rw, r)
+			return
+		}
+
+		cors.New(options).Handler(next).ServeHTTP(rw, r)
+	}
+}

--- a/corsx/middleware_test.go
+++ b/corsx/middleware_test.go
@@ -1,0 +1,70 @@
+package corsx
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rs/cors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/negroni"
+)
+
+func TestContextualizedMiddleware(t *testing.T) {
+	createServer := func(t *testing.T, cb func(ctx context.Context) (cors.Options, bool)) *httptest.Server {
+		n := negroni.New()
+		n.UseFunc(ContextualizedMiddleware(cb))
+		n.UseHandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			_, _ = rw.Write([]byte("ok"))
+		})
+		ts := httptest.NewServer(n)
+		t.Cleanup(ts.Close)
+		return ts
+	}
+
+	fetchCORS := func(t *testing.T, origin string, ts *httptest.Server) http.Header {
+		req, err := http.NewRequest("OPTIONS", ts.URL, nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", origin)
+		req.Header.Set("Access-Control-Request-Method", "DELETE")
+		req.Header.Set("Access-Control-Request-Headers", "origin")
+		res, err := ts.Client().Do(req)
+		require.NoError(t, err)
+		defer res.Body.Close()
+		return res.Header
+	}
+
+	t.Run("switches enabled on and off", func(t *testing.T) {
+		var enabled bool
+		var origins []string
+		ts := createServer(t, func(ctx context.Context) (cors.Options, bool) {
+			return cors.Options{
+				AllowedMethods: []string{"OPTIONS", "DELETE"},
+				AllowedOrigins: origins,
+				Debug:          true,
+			}, enabled
+		})
+
+		origins = append(origins, "http://localhost:8080")
+		actual := fetchCORS(t, "http://localhost:8080", ts)
+		assert.Empty(t, actual.Get("Access-Control-Allow-Origin"))
+
+		enabled = true
+		actual = fetchCORS(t, "http://localhost:8080", ts)
+		assert.Equal(t, "http://localhost:8080", actual.Get("Access-Control-Allow-Origin"), actual)
+
+		enabled = false
+		actual = fetchCORS(t, "http://localhost:8080", ts)
+		assert.Empty(t, actual.Get("Access-Control-Allow-Origin"))
+
+		enabled = true
+		origins = []string{"http://localhost:9090"}
+		actual = fetchCORS(t, "http://localhost:8080", ts)
+		assert.Empty(t, actual.Get("Access-Control-Allow-Origin"))
+
+		actual = fetchCORS(t, "http://localhost:9090", ts)
+		assert.Equal(t, "http://localhost:9090", actual.Get("Access-Control-Allow-Origin"), actual)
+	})
+}

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -82,11 +82,13 @@ func (f *Fetcher) fetchRemote(source string) (*bytes.Buffer, error) {
 }
 
 func (f *Fetcher) fetchFile(source string) (*bytes.Buffer, error) {
-	fp, err := os.Open(source)
+	fp, err := os.Open(source) //#nosec:G304
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to fetch from source: %s", source)
 	}
-	defer fp.Close()
+	defer func() {
+		_ = fp.Close()
+	}()
 
 	return f.decode(fp)
 }

--- a/jsonnetx/format.go
+++ b/jsonnetx/format.go
@@ -40,6 +40,7 @@ Use -w or --write to write output back to files instead of stdout.
 					fmt.Printf("Processing file: %s\n", file)
 				}
 
+				//#nosec G304 -- false positive
 				content, err := ioutil.ReadFile(file)
 				cmdx.Must(err, `Unable to read file "%s" because: %s`, file, err)
 

--- a/jsonnetx/lint.go
+++ b/jsonnetx/lint.go
@@ -39,6 +39,7 @@ var LintCommand = &cobra.Command{
 					fmt.Printf("Processing file: %s\n", file)
 				}
 
+				//#nosec G304 -- false positive
 				content, err := ioutil.ReadFile(file)
 				cmdx.Must(err, `Unable to read file "%s" because: %s`, file, err)
 

--- a/migratest/run.go
+++ b/migratest/run.go
@@ -22,8 +22,10 @@ func ContainsExpectedIds(t *testing.T, path string, ids []string) {
 		}
 	}
 }
+
 func CompareWithFixture(t *testing.T, actual interface{}, prefix string, id string) {
 	location := filepath.Join("fixtures", prefix, id+".json")
+	//#nosec G304 -- false positive
 	expected, err := ioutil.ReadFile(location)
 	WriteFixtureOnError(t, err, actual, location)
 

--- a/osx/file.go
+++ b/osx/file.go
@@ -153,6 +153,7 @@ func readFile(source string, o *options) (bytes []byte, err error) {
 			return nil, errors.New("file loader disabled")
 		}
 
+		//#nosec G304 -- false positive
 		bytes, err = os.ReadFile(source)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to read the file")
@@ -162,6 +163,7 @@ func readFile(source string, o *options) (bytes []byte, err error) {
 			return nil, errors.New("file loader disabled")
 		}
 
+		//#nosec G304 -- false positive
 		bytes, err = os.ReadFile(parsed.Host + parsed.Path)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to read the file")

--- a/pkgerx/file.go
+++ b/pkgerx/file.go
@@ -13,7 +13,7 @@ func MustRead(f pkging.File, err error) []byte {
 	if err != nil {
 		panic(err)
 	}
-	defer f.Close()
+	defer (func() { _ = f.Close() })()
 	return ioutilx.MustReadAll(f)
 }
 
@@ -22,6 +22,6 @@ func Read(f pkging.File, err error) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer (func() { _ = f.Close() })()
 	return ioutil.ReadAll(f)
 }

--- a/popx/migrator.go
+++ b/popx/migrator.go
@@ -493,13 +493,13 @@ func (m *Migrator) Status(ctx context.Context) (MigrationStatuses, error) {
 func (m *Migrator) DumpMigrationSchema(ctx context.Context) error {
 	c := m.Connection.WithContext(ctx)
 	schema := "schema.sql"
-	f, err := os.Create(schema)
+	f, err := os.Create(schema) //#nosec:G304) //#nosec:G304
 	if err != nil {
 		return err
 	}
 	err = c.Dialect.DumpSchema(f)
 	if err != nil {
-		os.RemoveAll(schema)
+		_ = os.RemoveAll(schema)
 		return err
 	}
 	return nil

--- a/sqlcon/dockertest/test_helper.go
+++ b/sqlcon/dockertest/test_helper.go
@@ -189,7 +189,7 @@ func runPosgreSQLCleanup() (string, func(), error) {
 	}
 
 	return fmt.Sprintf("postgres://postgres:secret@127.0.0.1:%s/postgres?sslmode=disable", resource.GetPort("5432/tcp")),
-		func() { pool.Purge(resource) }, nil
+		func() { _ = pool.Purge(resource) }, nil
 }
 
 // ConnectToTestPostgreSQL connects to a PostgreSQL database.
@@ -252,7 +252,7 @@ func runMySQLCleanup() (string, func(), error) {
 	}
 
 	return fmt.Sprintf("mysql://root:secret@(localhost:%s)/mysql?parseTime=true&multiStatements=true", resource.GetPort("3306/tcp")),
-		func() { pool.Purge(resource) }, nil
+		func() { _ = pool.Purge(resource) }, nil
 }
 
 // RunTestMySQL runs a MySQL database and returns the URL to it.
@@ -333,7 +333,7 @@ func runCockroachDBWithVersionCleanup(version string) (string, func(), error) {
 	}
 
 	return fmt.Sprintf("cockroach://root@localhost:%s/defaultdb?sslmode=disable", resource.GetPort("26257/tcp")),
-		func() { pool.Purge(resource) },
+		func() { _ = pool.Purge(resource) },
 		nil
 }
 

--- a/tracing/http_client.go
+++ b/tracing/http_client.go
@@ -33,7 +33,7 @@ func RoundTripper(tracer opentracing.Tracer, delegate http.RoundTripper) http.Ro
 			})
 		defer span.Finish()
 		carrier := opentracing.HTTPHeadersCarrier(req.Header)
-		span.Tracer().Inject(span.Context(), opentracing.HTTPHeaders, carrier)
+		_ = span.Tracer().Inject(span.Context(), opentracing.HTTPHeaders, carrier)
 
 		if delegate == nil {
 			delegate = http.DefaultTransport

--- a/watcherx/directory.go
+++ b/watcherx/directory.go
@@ -79,6 +79,8 @@ func handleEvent(e fsnotify.Event, w *fsnotify.Watcher, c EventChannel) {
 			}
 			return
 		}
+
+		//#nosec G304 -- false positive
 		data, err := ioutil.ReadFile(e.Name)
 		if err != nil {
 			c <- &ErrorEvent{
@@ -110,6 +112,7 @@ func streamDirectoryEvents(ctx context.Context, w *fsnotify.Watcher, c EventChan
 					return err
 				}
 				if !info.IsDir() {
+					//#nosec G304 -- false positive
 					data, err := ioutil.ReadFile(path)
 					if err != nil {
 						c <- &ErrorEvent{

--- a/watcherx/directory_test.go
+++ b/watcherx/directory_test.go
@@ -22,7 +22,7 @@ func TestWatchDirectory(t *testing.T) {
 		_, err := WatchDirectory(ctx, dir, c)
 		require.NoError(t, err)
 		fileName := filepath.Join(dir, "example")
-		f, err := os.Create(fileName)
+		f, err := os.Create(fileName) //#nosec:G304
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 
@@ -34,7 +34,7 @@ func TestWatchDirectory(t *testing.T) {
 		defer cancel()
 
 		fileName := filepath.Join(dir, "example")
-		f, err := os.Create(fileName)
+		f, err := os.Create(fileName) //#nosec:G304
 		require.NoError(t, err)
 		_, err = WatchDirectory(ctx, dir, c)
 		require.NoError(t, err)
@@ -50,7 +50,7 @@ func TestWatchDirectory(t *testing.T) {
 		defer cancel()
 
 		fileName := filepath.Join(dir, "example")
-		f, err := os.Create(fileName)
+		f, err := os.Create(fileName) //#nosec:G304
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 
@@ -72,7 +72,7 @@ func TestWatchDirectory(t *testing.T) {
 		require.NoError(t, err)
 
 		fileName := filepath.Join(childDir, "example")
-		f, err := os.Create(fileName)
+		f, err := os.Create(fileName) //#nosec:G304
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 
@@ -91,7 +91,7 @@ func TestWatchDirectory(t *testing.T) {
 		fileName := filepath.Join(childDir, "example")
 		// there's not much we can do about this timeout as it takes some time until the new watcher is created
 		time.Sleep(time.Millisecond)
-		f, err := os.Create(fileName)
+		f, err := os.Create(fileName) //#nosec:G304
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 
@@ -131,11 +131,11 @@ func TestWatchDirectory(t *testing.T) {
 		subChildDir := filepath.Join(childDir, "subchild")
 		require.NoError(t, os.MkdirAll(subChildDir, 0777))
 		f1 := filepath.Join(subChildDir, "f1")
-		f, err := os.Create(f1)
+		f, err := os.Create(f1) //#nosec:G304
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 		f2 := filepath.Join(childDir, "f2")
-		f, err = os.Create(f2)
+		f, err = os.Create(f2) //#nosec:G304
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 

--- a/watcherx/file.go
+++ b/watcherx/file.go
@@ -75,6 +75,7 @@ func streamFileEvents(ctx context.Context, watcher *fsnotify.Watcher, c EventCha
 				c <- &RemoveEvent{eventSource}
 			} else {
 				// The file does exist. Announce the current content by sending a ChangeEvent.
+				//#nosec G304 -- false positive
 				data, err := ioutil.ReadFile(watchedFile)
 				if err != nil {
 					c <- &ErrorEvent{
@@ -126,6 +127,7 @@ func streamFileEvents(ctx context.Context, watcher *fsnotify.Watcher, c EventCha
 					// we fallthrough because we also want to read the file in this case
 					fallthrough
 				case e.Op&(fsnotify.Write|fsnotify.Create) != 0:
+					//#nosec G304 -- false positive
 					data, err := ioutil.ReadFile(watchedFile)
 					if err != nil {
 						c <- &ErrorEvent{

--- a/watcherx/file_test.go
+++ b/watcherx/file_test.go
@@ -40,7 +40,7 @@ func TestFileWatcher(t *testing.T) {
 		defer cancel()
 
 		exampleFile := filepath.Join(dir, "example.file")
-		f, err := os.Create(exampleFile)
+		f, err := os.Create(exampleFile) //#nosec:G304
 		require.NoError(t, err)
 
 		_, err = WatchFile(ctx, exampleFile, c)
@@ -61,7 +61,7 @@ func TestFileWatcher(t *testing.T) {
 		_, err := WatchFile(ctx, exampleFile, c)
 		require.NoError(t, err)
 
-		f, err := os.Create(exampleFile)
+		f, err := os.Create(exampleFile) //#nosec:G304
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 
@@ -73,7 +73,7 @@ func TestFileWatcher(t *testing.T) {
 		defer cancel()
 
 		exampleFile := filepath.Join(dir, "example.file")
-		f, err := os.Create(exampleFile)
+		f, err := os.Create(exampleFile) //#nosec:G304
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 
@@ -84,7 +84,7 @@ func TestFileWatcher(t *testing.T) {
 
 		assertRemove(t, <-c, exampleFile)
 
-		f, err = os.Create(exampleFile)
+		f, err = os.Create(exampleFile) //#nosec:G304
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 
@@ -102,7 +102,7 @@ func TestFileWatcher(t *testing.T) {
 		otherDir, err := ioutil.TempDir("", "*")
 		require.NoError(t, err)
 		origFileName := filepath.Join(otherDir, "original")
-		f, err := os.Create(origFileName)
+		f, err := os.Create(origFileName) //#nosec:G304
 		require.NoError(t, err)
 
 		linkFileName := filepath.Join(dir, "slink")
@@ -130,10 +130,10 @@ func TestFileWatcher(t *testing.T) {
 		require.NoError(t, err)
 		fileOne := filepath.Join(otherDir, "fileOne")
 		fileTwo := filepath.Join(otherDir, "fileTwo")
-		f1, err := os.Create(fileOne)
+		f1, err := os.Create(fileOne) //#nosec:G304
 		require.NoError(t, err)
 		require.NoError(t, f1.Close())
-		f2, err := os.Create(fileTwo)
+		f2, err := os.Create(fileTwo) //#nosec:G304
 		require.NoError(t, err)
 		_, err = fmt.Fprintf(f2, "file two")
 		require.NoError(t, err)
@@ -162,7 +162,7 @@ func TestFileWatcher(t *testing.T) {
 		_, err := WatchFile(ctx, fileName, c)
 		require.NoError(t, err)
 
-		f, err := os.Create(fileName)
+		f, err := os.Create(fileName) //#nosec:G304
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 

--- a/watcherx/websocket_test.go
+++ b/watcherx/websocket_test.go
@@ -30,7 +30,7 @@ func TestWatchWebsocket(t *testing.T) {
 		l := logrusx.New("", "", logrusx.WithHook(hook))
 
 		fn := filepath.Join(dir, "some.file")
-		f, err := os.Create(fn)
+		f, err := os.Create(fn) //#nosec:G304
 		require.NoError(t, err)
 
 		url, err := urlx.Parse("file://" + fn)
@@ -137,7 +137,7 @@ func TestWatchWebsocket(t *testing.T) {
 		_, err = WatchWebsocket(ctxClient2, u, c2)
 		require.NoError(t, err)
 
-		f, err := os.Create(fn)
+		f, err := os.Create(fn) //#nosec:G304
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 
@@ -172,7 +172,7 @@ func TestWatchWebsocket(t *testing.T) {
 		_, err = WatchWebsocket(ctxClient2, u, c2)
 		require.NoError(t, err)
 
-		f, err := os.Create(fn)
+		f, err := os.Create(fn) //#nosec:G304
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 


### PR DESCRIPTION
@Benehiko PTAL https://github.com/ory/x/commit/e294636fb31bbe24969ffc42b5e17c3807b52783

We should use this CORS handler for backoffice, kratos and remove the CORS handling from the bo proxy so that oryapis.com can also have CORS