### PR TITLE
fix(popx): close file to fix resource leak

### DIFF
--- a/popx/migration_box.go
+++ b/popx/migration_box.go
@@ -200,6 +200,7 @@ func (fm *MigrationBox) findMigrations(runner func([]byte) func(mf Migration, c 
 		if err != nil {
 			return errors.WithStack(err)
 		}
+		defer f.Close()
 		content, err := io.ReadAll(f)
 		if err != nil {
 			return errors.WithStack(err)


### PR DESCRIPTION
Fix resource leak in `findMigrations`.