### PR TITLE
fix: remove support for JSONPatch 'test'

### DIFF
--- a/jsonx/patch_test.go
+++ b/jsonx/patch_test.go
@@ -113,4 +113,31 @@ func TestApplyJSONPatch(t *testing.T) {
 		require.NoError(t, ApplyJSONPatch(rawPatch, &obj, "/Field1"))
 		require.Equal(t, expected, obj)
 	})
+
+	t.Run("suite=invalid patches", func(t *testing.T) {
+		cases := []struct {
+			name  string
+			patch []byte
+		}{{
+			name:  "test",
+			patch: []byte(`[{"op": "test", "path": "/"}]`),
+		}, {
+			name:  "add",
+			patch: []byte(`[{"op": "add", "path": "/"}]`),
+		}, {
+			name:  "remove",
+			patch: []byte(`[{"op": "add", "path": "/"}]`),
+		}, {
+			name:  "replace",
+			patch: []byte(`[{"op": "add", "path": "/"}]`),
+		}}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(_ *testing.T) {
+				obj := &TestType{}
+				ApplyJSONPatch(tc.patch, &obj)
+			})
+		}
+	})
+
 }


### PR DESCRIPTION
json-patch panics when the operator is "test" and the value
is empty. Until this is fixed upstream, we disallow "test".

