### PR TITLE
fix(tracing): enable trace propagation for OTEL

### DIFF
--- a/otelx/otlp.go
+++ b/otelx/otlp.go
@@ -6,6 +6,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
@@ -43,6 +44,11 @@ func SetupOTLP(t *Tracer, tracerName string) (trace.Tracer, error) {
 
 	tp := sdktrace.NewTracerProvider(tpOpts...)
 	otel.SetTracerProvider(tp)
+
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
 
 	return tp.Tracer(tracerName), nil
 }

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/otel"
 	otelOpentracing "go.opentelemetry.io/otel/bridge/opentracing"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	otelSdkTrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
@@ -201,6 +202,11 @@ func (t *Tracer) setup() error {
 		)
 
 		otel.SetTracerProvider(tp)
+
+		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+			propagation.TraceContext{},
+			propagation.Baggage{},
+		))
 
 		bridge := otelOpentracing.NewBridgeTracer()
 		bridge.SetOpenTelemetryTracer(otel.Tracer(""))


### PR DESCRIPTION
The middleware already attempts to extract a parent trace from the HTTP
request. However, that does nothing unless a global OTEL propagator is
configured. This patch adds that configuration.

An alternative is to configure the propagator only for the otel Bridge:

    bridge := otelOpentracing.NewBridgeTracer()
    bridge.SetTextMapPropagator(...)

But considering that the bridge only exists due to the use of a
deprecated package it seems more appropriate to configure the global
propagator in the non-deprecated package.

## Why it didn't work before

The tracing middleware calls `remoteContext, _ := opentracing.GlobalTracer().Extract(...)` to get the parent span, if any:

https://github.com/ory/x/blob/df7f8ab7bc01df3c1584b2bd9d2c443197ea1157/tracing/middleware.go#L23-L27

`opentracing.GlobalTracer()` returns the bridge set up earlier:

https://github.com/ory/x/blob/df7f8ab7bc01df3c1584b2bd9d2c443197ea1157/tracing/tracer.go#L205-L209

`*BridgeTracer.Extract` uses either its configured propagator, or the global one:

```go
	ctx := t.getPropagator().Extract(context.Background(), propagation.HeaderCarrier(header))
```

```go
func (t *BridgeTracer) getPropagator() propagation.TextMapPropagator {
	if t.propagator != nil {
		return t.propagator
	}
	return otel.GetTextMapPropagator()
}
```

https://github.com/open-telemetry/opentelemetry-go/blob/4bf6150fa94e18bdf01c96ed78ee6d1c76f8e308/bridge/opentracing/bridge.go#L666

https://github.com/open-telemetry/opentelemetry-go/blob/4bf6150fa94e18bdf01c96ed78ee6d1c76f8e308/bridge/opentracing/bridge.go#L678-L683

The default global propagator is a noop implementation:

```go
func defaultPropagatorsValue() *atomic.Value {
	v := &atomic.Value{}
	v.Store(propagatorsHolder{tm: newTextMapPropagator()})
	return v
}
```

```go
func newTextMapPropagator() *textMapPropagator {
	return &textMapPropagator{
		noop: propagation.NewCompositeTextMapPropagator(),
	}
}
```

https://github.com/open-telemetry/opentelemetry-go/blob/19294aab4cd8b52afc34b77403e7447109c9b858/internal/global/state.go#L94-L98

https://github.com/open-telemetry/opentelemetry-go/blob/19294aab4cd8b52afc34b77403e7447109c9b858/internal/global/propagator.go#L38-L42

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation within the code base (if appropriate).