### PR TITLE
fix: migrator error handling

### DIFF
--- a/popx/migrator.go
+++ b/popx/migrator.go
@@ -325,7 +325,7 @@ func (m *Migrator) isolatedTransaction(ctx context.Context, direction string, fn
 	}
 
 	if dberr != nil {
-		return errors.Wrapf(err, "error committing or rolling back transaction: %v", dberr)
+		return errors.Wrapf(dberr, "error committing or rolling back transaction; original error: %v", err)
 	}
 
 	return err


### PR DESCRIPTION
Just took two days to figure out...

What was happening:
1. [huge migration](https://github.com/ory/keto/blob/d007bae4ce7b507f17f5c907bf90f858cfcd2950/internal/persistence/sql/migrations/uuidmapping/uuid_mapping_migrator.go) with ~100.000 rows against CRDB
2. no error during execution, but the commit errored with `restart transaction: TransactionRetryWithProtoRefreshError: TransactionAbortedError(ABORT_REASON_ABORTED_RECORD_FOUND)` because of low resources on my local laptop
3. therefore `err` was `nil`, but `dberr` was not
4. finally, `errors.Wrapf` was called with a `nil` error, and therefore silently droppend the non-nil `dberr`