### PR TITLE
test: remove assertion for time elapsed being less than magic number

### DIFF
--- a/reqlog/middleware_test.go
+++ b/reqlog/middleware_test.go
@@ -214,5 +214,4 @@ func TestRealClock_Since(t *testing.T) {
 	since := rc.Since(now)
 
 	assert.True(t, since >= napDuration)
-	assert.True(t, since < napDuration+6*time.Millisecond)
 }


### PR DESCRIPTION
This fixes a flaky assertion that depends on the process being resumed from sleep in less than 16 ms (nap duration - 10ms + 6ms arbitrary number). The other assertion which tests that the process sleeps for a minimum of the the nap duration defined is sufficient. 
