### PR TITLE
fix: `(*configx.Provider).TracingConfig` should parse all providers configs

### DIFF
--- a/configx/provider.go
+++ b/configx/provider.go
@@ -489,6 +489,19 @@ func (p *Provider) TracingConfig(serviceName string) *otelx.Config {
 				},
 				LocalAgentAddress: p.String("tracing.providers.jaeger.local_agent_address"),
 			},
+			Zipkin: otelx.ZipkinConfig{
+				ServerURL: p.String("tracing.providers.zipkin.server_url"),
+				Sampling: otelx.ZipkinSampling{
+					SamplingRatio: p.Float64("tracing.providers.zipkin.sampling.sampling_ratio"),
+				},
+			},
+			OTLP: otelx.OTLPConfig{
+				ServerURL: p.String("tracing.providers.otlp.server_url"),
+				Insecure:  p.Bool("tracing.providers.otlp.insecure"),
+				Sampling: otelx.OTLPSampling{
+					SamplingRatio: p.Float64("tracing.providers.otlp.sampling.sampling_ratio"),
+				},
+			},
 		},
 	}
 }

--- a/otelx/config.schema.json
+++ b/otelx/config.schema.json
@@ -70,11 +70,7 @@
               "type": "string",
               "description": "The address of the Zipkin server where spans should be sent to.",
               "format": "uri",
-              "examples": [
-                {
-                  "server_url": "http://localhost:9411/api/v2/spans"
-                }
-              ]
+              "examples": ["http://localhost:9411/api/v2/spans"]
             },
             "sampling": {
               "type": "object",
@@ -114,11 +110,7 @@
                   "pattern": "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9]):([0-9]*)$"
                 }
               ],
-              "examples": [
-                {
-                  "server_url": "localhost:4318"
-                }
-              ]
+              "examples": ["localhost:4318"]
             },
             "insecure": {
               "type": "boolean",


### PR DESCRIPTION
FYI @icyphox, this was also needed to get zipkin working :wink: 