### PR TITLE
chore: remove double tabs from Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,54 +16,54 @@ $(foreach dep, $(GO_DEPENDENCIES), $(eval $(call make-go-dependency, $(dep))))
 $(call make-lint-dependency)
 
 .bin/ory: Makefile
-		bash <(curl https://raw.githubusercontent.com/ory/cli/master/install.sh) -b .bin v0.0.53
-		touch -a -m .bin/ory
+	bash <(curl https://raw.githubusercontent.com/ory/cli/master/install.sh) -b .bin v0.0.53
+	touch -a -m .bin/ory
 
 .PHONY: format
 format: .bin/goimports node_modules
-		.bin/goimports -w -local github.com/ory .
-		npm exec -- prettier --write .
+	.bin/goimports -w -local github.com/ory .
+	npm exec -- prettier --write .
 
 .bin/goimports: Makefile
 	GOBIN=$(shell pwd)/.bin go install golang.org/x/tools/cmd/goimports@latest
 
 .bin/golangci-lint: Makefile
-		bash <(curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh) -d -b .bin v1.46.2
+	bash <(curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh) -d -b .bin v1.46.2
 
 .PHONY: test
 test:
-		make resetdb
-		export TEST_DATABASE_POSTGRESQL=postgres://postgres:secret@127.0.0.1:3445/hydra?sslmode=disable; export TEST_DATABASE_COCKROACHDB=cockroach://root@127.0.0.1:3446/defaultdb?sslmode=disable; export TEST_DATABASE_MYSQL='mysql://root:secret@tcp(127.0.0.1:3444)/mysql?parseTime=true&multiStatements=true'; go test -count=1 -tags sqlite ./...
+	make resetdb
+	export TEST_DATABASE_POSTGRESQL=postgres://postgres:secret@127.0.0.1:3445/hydra?sslmode=disable; export TEST_DATABASE_COCKROACHDB=cockroach://root@127.0.0.1:3446/defaultdb?sslmode=disable; export TEST_DATABASE_MYSQL='mysql://root:secret@tcp(127.0.0.1:3444)/mysql?parseTime=true&multiStatements=true'; go test -count=1 -tags sqlite ./...
 
 .PHONY: resetdb
 resetdb:
-		docker kill hydra_test_database_mysql || true
-		docker kill hydra_test_database_postgres || true
-		docker kill hydra_test_database_cockroach || true
-		docker rm -f hydra_test_database_mysql || true
-		docker rm -f hydra_test_database_postgres || true
-		docker rm -f hydra_test_database_cockroach || true
-		docker run --rm --name hydra_test_database_mysql -p 3444:3306 -e MYSQL_ROOT_PASSWORD=secret -d mysql:8.0
-		docker run --rm --name hydra_test_database_postgres -p 3445:5432 -e POSTGRES_PASSWORD=secret -e POSTGRES_DB=hydra -d postgres:11.8
-		docker run --rm --name hydra_test_database_cockroach -p 3446:26257 -d cockroachdb/cockroach:v21.1.2 start --insecure
+	docker kill hydra_test_database_mysql || true
+	docker kill hydra_test_database_postgres || true
+	docker kill hydra_test_database_cockroach || true
+	docker rm -f hydra_test_database_mysql || true
+	docker rm -f hydra_test_database_postgres || true
+	docker rm -f hydra_test_database_cockroach || true
+	docker run --rm --name hydra_test_database_mysql -p 3444:3306 -e MYSQL_ROOT_PASSWORD=secret -d mysql:8.0
+	docker run --rm --name hydra_test_database_postgres -p 3445:5432 -e POSTGRES_PASSWORD=secret -e POSTGRES_DB=hydra -d postgres:11.8
+	docker run --rm --name hydra_test_database_cockroach -p 3446:26257 -d cockroachdb/cockroach:v21.1.2 start --insecure
 
 .PHONY: lint
 lint: .bin/golangci-lint
-		GO111MODULE=on golangci-lint run -v ./...
+	GO111MODULE=on golangci-lint run -v ./...
 
 .PHONY: migrations-render
 migrations-render: .bin/ory
-		ory dev pop migration render networkx/migrations/templates networkx/migrations/sql
+	ory dev pop migration render networkx/migrations/templates networkx/migrations/sql
 
 .PHONY: migrations-render-replace
 migrations-render-replace: .bin/ory
-		ory dev pop migration render -r networkx/migrations/templates networkx/migrations/sql
+	ory dev pop migration render -r networkx/migrations/templates networkx/migrations/sql
 
 .PHONY: mocks
 mocks: .bin/mockgen
-		mockgen -package hasherx_test -destination hasherx/mocks_argon2_test.go github.com/ory/x/hasherx Argon2Configurator
-		mockgen -package hasherx_test -destination hasherx/mocks_bcrypt_test.go github.com/ory/x/hasherx BCryptConfigurator
-		mockgen -package hasherx_test -destination hasherx/mocks_pkdbf2_test.go github.com/ory/x/hasherx PBKDF2Configurator
+	mockgen -package hasherx_test -destination hasherx/mocks_argon2_test.go github.com/ory/x/hasherx Argon2Configurator
+	mockgen -package hasherx_test -destination hasherx/mocks_bcrypt_test.go github.com/ory/x/hasherx BCryptConfigurator
+	mockgen -package hasherx_test -destination hasherx/mocks_pkdbf2_test.go github.com/ory/x/hasherx PBKDF2Configurator
 
 node_modules: package-lock.json
 	npm ci


### PR DESCRIPTION
Reduces the indentation of Makefiles from double tabs to single tabs.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation within the code base (if appropriate).
