### PR TITLE
fix(pagination): fixed prev link with negative page value

### DIFF
--- a/pagination/pagepagination/pagination.go
+++ b/pagination/pagepagination/pagination.go
@@ -151,7 +151,7 @@ func PaginationHeader(w http.ResponseWriter, u *url.URL, total int64, page, item
 			return
 		}
 
-		if total < itemsPerPage64 {
+		if total <= itemsPerPage64 {
 			w.Header().Set("link", header(u, "first", total, 0))
 			return
 		}

--- a/pagination/pagepagination/pagination_test.go
+++ b/pagination/pagepagination/pagination_test.go
@@ -96,7 +96,7 @@ func TestPaginationHeader(t *testing.T) {
 		assert.EqualValues(t, "5", r.Result().Header.Get("X-Total-Count"))
 	})
 
-	t.Run("Create only first if the limits provided equls the number of clients found", func(t *testing.T) {
+	t.Run("Create only first if the limits provided equals the number of clients found", func(t *testing.T) {
 		r := httptest.NewRecorder()
 		PaginationHeader(r, u, 50, 0, 50)
 

--- a/pagination/pagepagination/pagination_test.go
+++ b/pagination/pagepagination/pagination_test.go
@@ -95,6 +95,16 @@ func TestPaginationHeader(t *testing.T) {
 		assert.EqualValues(t, expect, r.Result().Header.Get("Link"))
 		assert.EqualValues(t, "5", r.Result().Header.Get("X-Total-Count"))
 	})
+
+	t.Run("Create only first if the limits provided equls the number of clients found", func(t *testing.T) {
+		r := httptest.NewRecorder()
+		PaginationHeader(r, u, 50, 0, 50)
+
+		expect := "<http://example.com?page=0&per_page=50>; rel=\"first\""
+
+		assert.EqualValues(t, expect, r.Result().Header.Get("Link"))
+		assert.EqualValues(t, "50", r.Result().Header.Get("X-Total-Count"))
+	})
 }
 
 func TestParsePagination(t *testing.T) {


### PR DESCRIPTION
Fix pagination response headers unnecessarily including the "prev" link when the total count of items exactly matched the `per_page` pagination value.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related Issue or Design Document

I haven't created an issue for this bug, but I did briefly mention it in another PR here: https://github.com/ory/kratos/pull/2763#issuecomment-1261737747

**The issue:** Pagination response headers were including the "prev" link with the `page` query param set to `-1` when the total count of items exactly matched the page size. This fix simply omits the "prev" link in such a cases, because the single page already contains all items.

**How to reproduce:**
1. Get the total count for a paginated endpoint (total count should be less than the max allowed page size): 
```console
$ curl --verbose --location --request GET 'http://localhost:4434/admin/identities' 2>&1 | grep 'X-Total-Count\|Link'
< Link: <http://kratos:4434/identities?page=0&per_page=5>; rel="first"
< X-Total-Count: 5
```
2. Query the endpoint again but with `per_page` param equal to the total count. We expect to see only the "first" page link like the previous request, but we additionally receive the "prev" page link with an invalid page number.
```console
$ curl --verbose --location --request GET 'http://localhost:4434/admin/identities?per_page=5' 2>&1 | grep 'X-Total-Count\|Link'
< Link: <http://kratos:4434/identities?page=0&per_page=5>; rel="first",<http://kratos:4434/identities?page=-1&per_page=5>; rel="prev"
< X-Total-Count: 5
```

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
3. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
4. implements a new feature, link the issue containing the design document in the format of `#1234`;
5. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] **(n/a)** I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] **(n/a)** I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
