### PR TITLE
feat: enable ANSI_QUOTES sql_mode to interpret " as identifiers

### DIFF
--- a/sqlcon/parse_opts.go
+++ b/sqlcon/parse_opts.go
@@ -105,6 +105,7 @@ func FinalizeDSN(l *logrusx.Logger, dsn string) string {
 
 		q.Set("multiStatements", "true")
 		q.Set("parseTime", "true")
+		q.Set("sql_mode", "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,ANSI_QUOTES")
 
 		return fmt.Sprintf("%s?%s", parts[0], q.Encode())
 	}

--- a/sqlcon/parse_opts_test.go
+++ b/sqlcon/parse_opts_test.go
@@ -99,11 +99,11 @@ func TestFinalizeDSN(t *testing.T) {
 	}{
 		{
 			dsn:      "mysql://localhost",
-			expected: "mysql://localhost?multiStatements=true&parseTime=true",
+			expected: "mysql://localhost?multiStatements=true&parseTime=true&sql_mode=ONLY_FULL_GROUP_BY%2CSTRICT_TRANS_TABLES%2CNO_ZERO_IN_DATE%2CNO_ZERO_DATE%2CERROR_FOR_DIVISION_BY_ZERO%2CNO_ENGINE_SUBSTITUTION%2CANSI_QUOTES",
 		},
 		{
 			dsn:      "mysql://localhost?multiStatements=true&parseTime=true",
-			expected: "mysql://localhost?multiStatements=true&parseTime=true",
+			expected: "mysql://localhost?multiStatements=true&parseTime=true&sql_mode=ONLY_FULL_GROUP_BY%2CSTRICT_TRANS_TABLES%2CNO_ZERO_IN_DATE%2CNO_ZERO_DATE%2CERROR_FOR_DIVISION_BY_ZERO%2CNO_ENGINE_SUBSTITUTION%2CANSI_QUOTES",
 		},
 		{
 			dsn:      "postgres://localhost",


### PR DESCRIPTION
https://github.com/ory/x/pull/623 introduced a change to support using reserved keywords for pagination key column. This breaks queries on MySQL. 

The query parameter `sql_mode` is set to enable `ANSI_QUOTES` along with the defaults 

Reference to MySQL doc - https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_ansi_quotes