### PR TITLE
feat: add ordering to keyset paginator

### DIFF
--- a/pagination/keysetpagination/paginator.go
+++ b/pagination/keysetpagination/paginator.go
@@ -66,8 +66,7 @@ func Paginate[I Item](p *Paginator) pop.ScopeFunc {
 		eid := q.Connection.Dialect.Quote(id)
 		return q.
 			Limit(p.Size()+1).
-			Where(fmt.Sprintf(`%s > ?`, eid), p.Token()).
-			Order(fmt.Sprintf(`%s ASC`, eid))
+			Where(fmt.Sprintf(`%s > ?`, eid), p.Token())
 	}
 }
 

--- a/pagination/keysetpagination/paginator_test.go
+++ b/pagination/keysetpagination/paginator_test.go
@@ -32,7 +32,7 @@ func TestPaginator(t *testing.T) {
 		q = q.Scope(Paginate[testItem](paginator))
 
 		sql, args := q.ToSQL(&pop.Model{Value: new(testItem)})
-		assert.Equal(t, "SELECT test_items.pk FROM test_items AS test_items WHERE \"pk\" > $1 ORDER BY \"pk\" ASC LIMIT 11", sql)
+		assert.Equal(t, "SELECT test_items.pk FROM test_items AS test_items WHERE \"pk\" > $1 LIMIT 11", sql)
 		assert.Equal(t, []interface{}{"token"}, args)
 	})
 
@@ -46,7 +46,7 @@ func TestPaginator(t *testing.T) {
 		q = q.Scope(Paginate[testItem](paginator))
 
 		sql, args := q.ToSQL(&pop.Model{Value: new(testItem)})
-		assert.Equal(t, "SELECT test_items.pk FROM test_items AS test_items WHERE `pk` > ? ORDER BY `pk` ASC LIMIT 11", sql)
+		assert.Equal(t, "SELECT test_items.pk FROM test_items AS test_items WHERE `pk` > ? LIMIT 11", sql)
 		assert.Equal(t, []interface{}{"token"}, args)
 	})
 


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

Adds optional ordering to the `keysetpagination`. 

## Related Issue or Design Document

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments


The following snippets use the session listing API of Kratos and `jq`

```bash
$ curl localhost:4434/admin/sessions | jq '.[] | {authenticated_at: .authenticated_at, id: .id}'
```

And the following persister line:

```go
q.Scope(keysetpagination.Paginate[session.Session](paginator)).Order("authenticated_at DESC").All(&s)
```
Without this change (note the literal alphabetical sort of the UUIDs):
```json
{
  "authenticated_at": "2022-11-21T20:08:40.959955721Z",
  "id": "607fefca-85e2-4de9-96fc-a311f0fb94ec"
}
{
  "authenticated_at": "2022-11-18T09:47:38.442656796Z",
  "id": "a5f43280-de1e-4d87-a3da-44f866b9a41a"
}
{
  "authenticated_at": "2022-11-21T20:08:46.562888876Z",
  "id": "d4ecf7a9-3377-42db-aa30-f0cc7a39b389"
}
```

With this change (sorted by the timestamp):

```json
{
  "authenticated_at": "2022-11-21T20:08:46.562888876Z",
  "id": "d4ecf7a9-3377-42db-aa30-f0cc7a39b389"
}
{
  "authenticated_at": "2022-11-21T20:08:40.959955721Z",
  "id": "607fefca-85e2-4de9-96fc-a311f0fb94ec"
}
{
  "authenticated_at": "2022-11-18T09:47:38.442656796Z",
  "id": "a5f43280-de1e-4d87-a3da-44f866b9a41a"
}
```

See also https://github.com/ory/x/pull/615#discussion_r991994217

cc @zepatrik 
