### PR TITLE
fix: assignment to entry in nil map error when handling HTTP header CLI arguments

### DIFF
--- a/cmdx/http.go
+++ b/cmdx/http.go
@@ -87,7 +87,7 @@ func NewClient(cmd *cobra.Command) (*http.Client, *url.URL, error) {
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
-	var header http.Header
+	header := http.Header{}
 	for _, h := range rawHeaders {
 		parts := strings.Split(h, ":")
 		if len(parts) != 2 {


### PR DESCRIPTION
Fix an issue that causes the Hydra CLI to crash. Potentially affects any CLI that depends on `ory/x/cmdx`.

## Related Issue or Design Document

Fixes https://github.com/ory/hydra/issues/3370

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

Ideally there should be unit tests covering `http.go` but at the moment I don't have time to add them in this PR.
