### PR TITLE
fix: operator precendence in keysetpagination

### DIFF
--- a/pagination/keysetpagination/paginator.go
+++ b/pagination/keysetpagination/paginator.go
@@ -110,7 +110,7 @@ func (p *Paginator) multipleOrderFieldsQuery(q *pop.Query, idField string, cols 
 	}
 
 	q.
-		Where(fmt.Sprintf("%s %s ? OR (%s = ? AND %s > ?)", quoteName, sign, quoteName, quote(idField)), value, value, idValue).
+		Where(fmt.Sprintf("(%s %s ? OR (%s = ? AND %s > ?))", quoteName, sign, quoteName, quote(idField)), value, value, idValue).
 		Order(fmt.Sprintf("%s %s", quoteName, keyword))
 
 }

--- a/pagination/keysetpagination/paginator_test.go
+++ b/pagination/keysetpagination/paginator_test.go
@@ -185,13 +185,13 @@ func TestPaginateWithAdditionalColumn(t *testing.T) {
 		{
 			d:    "with sort by created_at DESC",
 			opts: []Option{WithToken(MapPageToken{"pk": "token_value", "created_at": "timestamp"}), WithColumn("created_at", "DESC")},
-			e:    `WHERE "created_at" < $1 OR ("created_at" = $2 AND "pk" > $3) ORDER BY "created_at" DESC, "pk" ASC`,
+			e:    `WHERE ("created_at" < $1 OR ("created_at" = $2 AND "pk" > $3)) ORDER BY "created_at" DESC, "pk" ASC`,
 			args: []interface{}{"timestamp", "timestamp", "token_value"},
 		},
 		{
 			d:    "with sort by created_at ASC",
 			opts: []Option{WithToken(MapPageToken{"pk": "token_value", "created_at": "timestamp"}), WithColumn("created_at", "ASC")},
-			e:    `WHERE "created_at" > $1 OR ("created_at" = $2 AND "pk" > $3) ORDER BY "created_at" ASC, "pk" ASC`,
+			e:    `WHERE ("created_at" > $1 OR ("created_at" = $2 AND "pk" > $3)) ORDER BY "created_at" ASC, "pk" ASC`,
 			args: []interface{}{"timestamp", "timestamp", "token_value"},
 		},
 		{


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->
Fixes the operator precedence in `keysetpagination` queries. 


## Related Issue or Design Document

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
Before this change the queries that resulted from the `keysetpagination` looked like this:

```sql
SELECT
  *
FROM
  courier_messages
WHERE
  nid = $1
  AND "created_at" < $2
  OR (
    "created_at" = $2
    AND "id" > $3
  )
ORDER BY
  "created_at" DESC,
  "id" ASC
LIMIT
  11
```

This could lead to the `nid = $1` clause being ignored.

This PR fixes that by turning the above statement into:

```sql
SELECT
  *
FROM
  courier_messages
WHERE
  nid = $1
  AND (
    "created_at" < $2
    OR (
      "created_at" = $2
      AND "id" > $3
    )
  )
ORDER BY
  "created_at" DESC,
  "id" ASC
LIMIT
  11
```
