### PR TITLE
fix: spurious spans from config reloader

### DIFF
--- a/configx/options.go
+++ b/configx/options.go
@@ -26,7 +26,6 @@ type (
 
 func WithContext(ctx context.Context) OptionModifier {
 	return func(p *Provider) {
-		p.originalContext = ctx
 		for _, o := range ConfigOptionsFromContext(ctx) {
 			o(p)
 		}

--- a/otelx/withspan_test.go
+++ b/otelx/withspan_test.go
@@ -42,6 +42,12 @@ func TestWithSpan(t *testing.T) {
 	})
 }
 
+func returnsNormally(ctx context.Context) (err error) {
+	_, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("").Start(ctx, "returnsNormally")
+	defer End(span, &err)
+	return nil
+}
+
 func returnsError(ctx context.Context) (err error) {
 	_, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("").Start(ctx, "returnsError")
 	defer End(span, &err)
@@ -49,7 +55,7 @@ func returnsError(ctx context.Context) (err error) {
 }
 
 func returnsNamedError(ctx context.Context) (err error) {
-	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("").Start(ctx, "returnsNamedError")
+	_, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("").Start(ctx, "returnsNamedError")
 	defer End(span, &err)
 	err2 := errors.New("err2 message")
 	return err2
@@ -67,16 +73,36 @@ func TestEnd(t *testing.T) {
 	ctx, span := tracer.Start(context.Background(), "parent")
 	defer span.End()
 
+	assert.NoError(t, returnsNormally(ctx))
+	require.NotEmpty(t, recorder.Ended())
+	assert.Equal(t, last(recorder).Name(), "returnsNormally")
+	assert.Equal(t, last(recorder).Status(), sdktrace.Status{codes.Unset, ""})
+
 	assert.Errorf(t, returnsError(ctx), "error from returnsError()")
 	require.NotEmpty(t, recorder.Ended())
-	assert.Equal(t, recorder.Ended()[len(recorder.Ended())-1].Status(), sdktrace.Status{codes.Error, "error from returnsError()"})
+	assert.Equal(t, last(recorder).Name(), "returnsError")
+	assert.Equal(t, last(recorder).Status(), sdktrace.Status{codes.Error, "error from returnsError()"})
 
 	assert.Errorf(t, returnsNamedError(ctx), "err2 message")
 	require.NotEmpty(t, recorder.Ended())
-	assert.Equal(t, recorder.Ended()[len(recorder.Ended())-1].Status(), sdktrace.Status{codes.Error, "err2 message"})
+	assert.Equal(t, last(recorder).Name(), "returnsNamedError")
+	assert.Equal(t, last(recorder).Status(), sdktrace.Status{codes.Error, "err2 message"})
 
 	assert.PanicsWithError(t, "panic from panics()", func() { panics(ctx) })
 	require.NotEmpty(t, recorder.Ended())
-	assert.Equal(t, recorder.Ended()[len(recorder.Ended())-1].Status(), sdktrace.Status{codes.Error, "panic: panic from panics()"})
+	assert.Equal(t, last(recorder).Name(), "panics")
+	assert.Equal(t, last(recorder).Status(), sdktrace.Status{codes.Error, "panic: panic from panics()"})
 
+	span.End()
+	require.NotEmpty(t, recorder.Ended())
+	assert.Equal(t, last(recorder).Name(), "parent")
+	assert.Equal(t, last(recorder).Status(), sdktrace.Status{codes.Unset, ""})
+}
+
+func last(r *tracetest.SpanRecorder) sdktrace.ReadOnlySpan {
+	ended := r.Ended()
+	if len(ended) == 0 {
+		return nil
+	}
+	return ended[len(ended)-1]
 }

--- a/watcherx/file.go
+++ b/watcherx/file.go
@@ -13,6 +13,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// WatchFile spawns a background goroutine to watch file, reporting any changes
+// to c. When initially starting to watch the file fails, c is closed. Watching
+// stops when ctx is canceled, at which point c is also closed.
 func WatchFile(ctx context.Context, file string, c EventChannel) (Watcher, error) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {


### PR DESCRIPTION
I've disassociated the context used for tracing during config reloads from what's being set in `configx.WithContext`.

More generally, I feel we store too much stuff in contexts and have too much magic of injecting configuration. We also store contexts inside structures occasionally, which is an anti-pattern. I'd like to clean this up more after this PR. 