### PR TITLE
fix(watcherx): go routine leak

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Start cockroach
         run:
           docker run --name cockroach -p 26257:26257 -d
-          cockroachdb/cockroach:v20.2.5 start-single-node --insecure
+          cockroachdb/cockroach:v22.2.5 start-single-node --insecure
       - name: Checkout repository
         uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -63,9 +63,9 @@ jobs:
           args: --timeout 2m
       - name: Install cockroach DB
         run: |
-          curl https://binaries.cockroachdb.com/cockroach-v21.1.2.linux-amd64.tgz | tar -xz
-          sudo cp -iv cockroach-v21.1.2.linux-amd64/cockroach /usr/local/bin/
-          rm -rf cockroach-v21.1.2.linux-amd64
+          curl https://binaries.cockroachdb.com/cockroach-v22.2.5.linux-amd64.tgz | tar -xz
+          sudo cp -iv cockroach-v22.2.5.linux-amd64/cockroach /usr/local/bin/
+          rm -rf cockroach-v22.2.5.linux-amd64
           cockroach version
       - name: Prepare nancy dependency list
         run: go list -json -deps > go.list

--- a/watcherx/file_test.go
+++ b/watcherx/file_test.go
@@ -37,7 +37,7 @@ func assertRemove(t *testing.T, e Event, src string) {
 	assert.Equal(t, &RemoveEvent{source(src)}, e)
 }
 
-func TestFileWatcher(t *testing.T) {
+func TestWatchFile(t *testing.T) {
 	t.Run("case=notifies on file write", func(t *testing.T) {
 		ctx, c, dir, cancel := setup(t)
 		defer cancel()

--- a/watcherx/testmain_test.go
+++ b/watcherx/testmain_test.go
@@ -1,0 +1,18 @@
+// Copyright © 2023 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package watcherx
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m,
+		goleak.IgnoreCurrent(),
+		// no idea where that comes from...
+		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
+	)
+}

--- a/watcherx/websocket_test.go
+++ b/watcherx/websocket_test.go
@@ -6,7 +6,6 @@ package watcherx
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -42,6 +41,7 @@ func TestWatchWebsocket(t *testing.T) {
 		handler, err := WatchAndServeWS(ctx, url, herodot.NewJSONWriter(l))
 		require.NoError(t, err)
 		s := httptest.NewServer(handler)
+		defer s.Close()
 
 		u := urlx.ParseOrPanic("ws" + strings.TrimLeft(s.URL, "http"))
 		_, err = WatchWebsocket(ctx, u, c)
@@ -70,6 +70,7 @@ func TestWatchWebsocket(t *testing.T) {
 		handler, err := WatchAndServeWS(ctx1, urlx.ParseOrPanic("file://"+fn), herodot.NewJSONWriter(l))
 		require.NoError(t, err)
 		s := httptest.NewServer(handler)
+		defer s.Close()
 
 		ctx2, cancel2 := context.WithCancel(context.Background())
 		u := urlx.ParseOrPanic("ws" + strings.TrimLeft(s.URL, "http"))
@@ -97,6 +98,7 @@ func TestWatchWebsocket(t *testing.T) {
 		handler, err := WatchAndServeWS(ctxServe, urlx.ParseOrPanic("file://"+fn), herodot.NewJSONWriter(l))
 		require.NoError(t, err)
 		s := httptest.NewServer(handler)
+		defer s.Close()
 
 		u := urlx.ParseOrPanic("ws" + strings.TrimLeft(s.URL, "http"))
 		_, err = WatchWebsocket(ctxClient, u, c)
@@ -122,6 +124,7 @@ func TestWatchWebsocket(t *testing.T) {
 		handler, err := WatchAndServeWS(ctxServer, urlx.ParseOrPanic("file://"+fn), herodot.NewJSONWriter(l))
 		require.NoError(t, err)
 		s := httptest.NewServer(handler)
+		defer s.Close()
 
 		ctxClient1, cancelClient1 := context.WithCancel(context.Background())
 		defer cancelClient1()
@@ -161,6 +164,7 @@ func TestWatchWebsocket(t *testing.T) {
 		handler, err := WatchAndServeWS(ctxServer, urlx.ParseOrPanic("file://"+fn), herodot.NewJSONWriter(l))
 		require.NoError(t, err)
 		s := httptest.NewServer(handler)
+		defer s.Close()
 
 		ctxClient1, cancelClient1 := context.WithCancel(context.Background())
 		defer cancelClient1()
@@ -197,11 +201,12 @@ func TestWatchWebsocket(t *testing.T) {
 
 		fn := filepath.Join(dir, "some.file")
 		initialContent := "initial content"
-		require.NoError(t, ioutil.WriteFile(fn, []byte(initialContent), 0600))
+		require.NoError(t, os.WriteFile(fn, []byte(initialContent), 0600))
 
 		handler, err := WatchAndServeWS(ctxServer, urlx.ParseOrPanic("file://"+fn), herodot.NewJSONWriter(l))
 		require.NoError(t, err)
 		s := httptest.NewServer(handler)
+		defer s.Close()
 
 		ctxClient, cancelClient := context.WithCancel(context.Background())
 		defer cancelClient()


### PR DESCRIPTION
This fixes another goroutine leak, manifesting as this test flake: https://github.com/ory/x/actions/runs/4231863448/jobs/7350899773#step:12:489

```
goleak: Errors on successful test run: found unexpected goroutines:
[Goroutine 108 in state select, with github.com/fsnotify/fsnotify.(*Watcher).sendEvent on top of the stack:
goroutine 108 [select]:
github.com/fsnotify/fsnotify.(*Watcher).sendEvent(...)
	/home/runner/go/pkg/mod/github.com/fsnotify/fsnotify@v1.6.0/backend_inotify.go:156
github.com/fsnotify/fsnotify.(*Watcher).readEvents(0xc0009d1630)
	/home/runner/go/pkg/mod/github.com/fsnotify/fsnotify@v1.6.0/backend_inotify.go:429 +0x705
created by github.com/fsnotify/fsnotify.NewWatcher
	/home/runner/go/pkg/mod/github.com/fsnotify/fsnotify@v1.6.0/backend_inotify.go:150 +0x1b0

 Goroutine 109 in state chan send, with github.com/ory/x/watcherx.streamFileEvents on top of the stack:
goroutine 109 [chan send]:
github.com/ory/x/watcherx.streamFileEvents({0x1239708, 0xc000677f80}, 0xc0009d1630, 0xc0004de240, 0xc0004de540, 0x3?, {0xc000979e00, 0x47}, {0xc0003bc4d0, 0x68})
	/home/runner/work/x/x/watcherx/file.go:106 +0x345
created by github.com/ory/x/watcherx.WatchFile
	/home/runner/work/x/x/watcherx/file.go:43 +0x4f8
]
```