### PR TITLE
fix: health/alive handler never errors

### DIFF
--- a/healthx/handler.go
+++ b/healthx/handler.go
@@ -123,7 +123,6 @@ func (h *Handler) SetVersionRoutes(r router, opts ...Options) {
 //
 //	Responses:
 //	  200: healthStatus
-//	  500: genericError
 func (h *Handler) Alive() http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		h.H.Write(rw, r, &swaggerHealthStatus{

--- a/healthx/handler.go
+++ b/healthx/handler.go
@@ -120,9 +120,11 @@ func (h *Handler) SetVersionRoutes(r router, opts ...Options) {
 //
 //	Produces:
 //	- application/json
+//	- text/plain
 //
 //	Responses:
 //	  200: healthStatus
+//	  default: unexpectedError
 func (h *Handler) Alive() http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		h.H.Write(rw, r, &swaggerHealthStatus{
@@ -130,6 +132,12 @@ func (h *Handler) Alive() http.Handler {
 		})
 	})
 }
+
+// swagger:model unexpectedError
+//
+//nolint:deadcode,unused
+//lint:ignore U1000 Used to generate Swagger and OpenAPI definitions
+type unexpectedError string
 
 // Ready returns an ok status if the instance is ready to handle HTTP requests and all ReadyCheckers are ok.
 //
@@ -148,10 +156,12 @@ func (h *Handler) Alive() http.Handler {
 //
 //	Produces:
 //	- application/json
+//	- text/plain
 //
 //	Responses:
 //	  200: healthStatus
 //	  503: healthNotReadyStatus
+//	  default: unexpectedError
 func (h *Handler) Ready(shareErrors bool) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		var notReady = swaggerNotReadyStatus{

--- a/healthx/handler_test.go
+++ b/healthx/handler_test.go
@@ -6,7 +6,7 @@ package healthx
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -67,7 +67,7 @@ func TestHealth(t *testing.T) {
 		response, err := c.Get(endpoint)
 		require.NoError(t, err)
 		require.EqualValues(t, http.StatusServiceUnavailable, response.StatusCode)
-		out, err := ioutil.ReadAll(response.Body)
+		out, err := io.ReadAll(response.Body)
 		require.NoError(t, err)
 		assert.Equal(t, "{\"error\":{\"code\":500,\"status\":\"Internal Server Error\",\"message\":\"not alive\"}}", strings.TrimSpace(string(out)))
 		return response

--- a/healthx/openapi/patch.yaml
+++ b/healthx/openapi/patch.yaml
@@ -24,7 +24,13 @@
                   status:
                     description: Always "ok".
                     type: string
-          description: {{.ProjectHumanName}} is ready to accept connections.
+          description: '{{.ProjectHumanName}} is ready to accept connections.'
+        default:
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Unexpected error
       summary: Check HTTP Server Status
       tags: {{ .HealthPathTags | toJson }}
 - op: replace
@@ -53,7 +59,7 @@
                   status:
                     description: Always "ok".
                     type: string
-          description: {{.ProjectHumanName}} is ready to accept requests.
+          description: '{{.ProjectHumanName}} is ready to accept requests.'
         '503':
           content:
             application/json:
@@ -68,6 +74,12 @@
                     type: object
                 type: object
           description: Ory Kratos is not yet ready to accept requests.
+        default:
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Unexpected error
       summary: Check HTTP Server and Database Status
       tags: {{ .HealthPathTags | toJson }}
 - op: replace

--- a/healthx/openapi/patch.yaml
+++ b/healthx/openapi/patch.yaml
@@ -25,12 +25,6 @@
                     description: Always "ok".
                     type: string
           description: {{.ProjectHumanName}} is ready to accept connections.
-        '500':
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/genericError"
-          description: genericError
       summary: Check HTTP Server Status
       tags: {{ .HealthPathTags | toJson }}
 - op: replace


### PR DESCRIPTION
This is problematic during code generation in downstream projects ever since https://github.com/ory/herodot/pull/106. Since the handler never returns an error (a failing liveness check means you don't get a response at all), the simplest and most correct thing to do is to just not declare an error type at all.
