### PR TITLE
fix(jsonx): enable PATCHing an object's field when the object does not exist yet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/cockroachdb/cockroach-go/v2 v2.2.16
 	github.com/dgraph-io/ristretto v0.1.1
 	github.com/docker/docker v20.10.24+incompatible
-	github.com/evanphx/json-patch v5.6.0+incompatible
+	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/fatih/structs v1.1.0
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
-github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
+github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
@@ -560,6 +560,7 @@ github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dv
 github.com/jandelgado/gcov2lcov v1.0.4/go.mod h1:NnSxK6TMlg1oGDBfGelGbjgorT5/L3cchlbtgFYZSss=
 github.com/jandelgado/gcov2lcov v1.0.5 h1:rkBt40h0CVK4oCb8Dps950gvfd1rYvQ8+cWa346lVU0=
 github.com/jandelgado/gcov2lcov v1.0.5/go.mod h1:NnSxK6TMlg1oGDBfGelGbjgorT5/L3cchlbtgFYZSss=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.4/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=

--- a/jsonx/patch.go
+++ b/jsonx/patch.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	jsonpatch "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 )
 
 var opAllowList = map[string]struct{}{

--- a/jsonx/patch.go
+++ b/jsonx/patch.go
@@ -47,7 +47,10 @@ func ApplyJSONPatch(p json.RawMessage, object interface{}, denyPaths ...string) 
 		return err
 	}
 
-	modified, err := patch.Apply(original)
+	options := jsonpatch.NewApplyOptions()
+	options.EnsurePathExistsOnAdd = true
+
+	modified, err := patch.ApplyWithOptions(original, options)
 	if err != nil {
 		return err
 	}

--- a/jsonx/patch_test.go
+++ b/jsonx/patch_test.go
@@ -17,6 +17,9 @@ type TestType struct {
 		Field1 bool
 		Field2 []int
 	}
+	FieldNull *struct {
+		Field1 any
+	}
 }
 
 func TestApplyJSONPatch(t *testing.T) {
@@ -112,6 +115,17 @@ func TestApplyJSONPatch(t *testing.T) {
 		rawPatch := []byte(`[{"op": "add", "path": "/Field2/-", "value": "bar"}]`)
 		expected := deepcopy.Copy(object).(TestType)
 		expected.Field2 = append(expected.Field2, "bar")
+		obj := deepcopy.Copy(object).(TestType)
+		require.NoError(t, ApplyJSONPatch(rawPatch, &obj, "/Field1"))
+		require.Equal(t, expected, obj)
+	})
+	t.Run("case=patch object field when object null", func(t *testing.T) {
+		rawPatch := []byte(`[{"op": "add", "path": "/FieldNull/Field1", "value": "bar"}]`)
+		expected := deepcopy.Copy(object).(TestType)
+		expected.FieldNull = &struct {
+			Field1 any
+		}{}
+		expected.FieldNull.Field1 = "bar"
 		obj := deepcopy.Copy(object).(TestType)
 		require.NoError(t, ApplyJSONPatch(rawPatch, &obj, "/Field1"))
 		require.Equal(t, expected, obj)


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

This PR fixes https://github.com/ory/kratos/issues/3244, which fails to add a field to `metadata_public`/`metadata_admin` when nothing yet exists in that object / when the objects are null.

To achieve this we instruct json-patch to create the missing path.

I had to update to a different version of `json-patch` I hope it's fine 🥹

## Related Issue or Design Document

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->
https://github.com/ory/kratos/issues/3244
https://ory-community.slack.com/archives/C012USDT5QQ/p1685968287885839

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
It's still TBD whether we should introduce the change globally or only enable the new behavior via a dedicated option.

I'm happy to work on changing the behavior by introducing a dedicated option (if that's required).

However, I would imagine that other APIs may also benefit from the change?!
