### PR TITLE
fix(decoderx): allow unknown fields

### DIFF
--- a/decoderx/http.go
+++ b/decoderx/http.go
@@ -550,7 +550,6 @@ func (t *HTTP) decodeJSON(r *http.Request, destination interface{}, o *httpDecod
 	}
 
 	dc := json.NewDecoder(bytes.NewReader(raw))
-	dc.DisallowUnknownFields()
 	if err := dc.Decode(destination); err != nil {
 		return errors.WithStack(herodot.ErrBadRequest.WithReasonf("Unable to decode JSON payload: %s", err))
 	}


### PR DESCRIPTION
An oversight in https://github.com/ory/x/commit/c8bd35e3bcceec8001475a4b8ee44700aa6ba382#diff-596c1a0e52378833155314a336e270dcdec55f3c79bc0cc88f0204c8b49369feR552-R554 caused a breaking change. This restores the old behavior.