### PR TITLE
feat(proxy): flag to keep forwarded headers

### DIFF
--- a/jsonx/patch.go
+++ b/jsonx/patch.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/evanphx/json-patch/v5"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 
 	"github.com/ory/x/pointerx"
 )

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -5,10 +5,11 @@ package proxy
 
 import (
 	"context"
-	"github.com/pkg/errors"
 	"log"
 	"net/http"
 	"net/http/httputil"
+
+	"github.com/pkg/errors"
 
 	"github.com/rs/cors"
 	"go.opentelemetry.io/otel"

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -18,7 +18,7 @@ import (
 type (
 	RespMiddleware func(resp *http.Response, config *HostConfig, body []byte) ([]byte, error)
 	ReqMiddleware  func(req *httputil.ProxyRequest, config *HostConfig, body []byte) ([]byte, error)
-	HostMapper     func(ctx context.Context, r *http.Request) (*HostConfig, error)
+	HostMapper     func(ctx context.Context, r *http.Request) (context.Context, *HostConfig, error)
 	options        struct {
 		hostMapper      HostMapper
 		onResError      func(*http.Response, error) error
@@ -99,7 +99,7 @@ func rewriter(o *options) func(*httputil.ProxyRequest) {
 		ctx, span := otel.GetTracerProvider().Tracer("").Start(ctx, "x.proxy")
 		defer span.End()
 
-		c, err := o.getHostConfig(r.In)
+		ctx, c, err := o.getHostConfig(ctx, r.In)
 		if err != nil {
 			o.onReqError(r.Out, err)
 			return
@@ -112,7 +112,6 @@ func rewriter(o *options) func(*httputil.ProxyRequest) {
 		c.setScheme(r)
 		c.setHost(r)
 
-		*r.Out = *r.Out.WithContext(context.WithValue(ctx, hostConfigKey, c))
 		headerRequestRewrite(r.Out, c)
 
 		var body []byte
@@ -148,7 +147,7 @@ func rewriter(o *options) func(*httputil.ProxyRequest) {
 // modifyResponse is a custom internal function for altering a http.Response
 func modifyResponse(o *options) func(*http.Response) error {
 	return func(r *http.Response) error {
-		c, err := o.getHostConfig(r.Request)
+		_, c, err := o.getHostConfig(r.Request.Context(), r.Request)
 		if err != nil {
 			return err
 		}
@@ -216,24 +215,24 @@ func WithErrorHandler(eh func(w http.ResponseWriter, r *http.Request, err error)
 	}
 }
 
-func (o *options) getHostConfig(r *http.Request) (*HostConfig, error) {
-	if cached, ok := r.Context().Value(hostConfigKey).(*HostConfig); ok && cached != nil {
-		return cached, nil
+func (o *options) getHostConfig(ctx context.Context, r *http.Request) (context.Context, *HostConfig, error) {
+	if cached, ok := ctx.Value(hostConfigKey).(*HostConfig); ok && cached != nil {
+		return ctx, cached, nil
 	}
-	c, err := o.hostMapper(r.Context(), r)
+	ctx, c, err := o.hostMapper(ctx, r)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	// cache the host config in the request context
 	// this will be passed on to the request and response proxy functions
-	*r = *r.WithContext(context.WithValue(r.Context(), hostConfigKey, c))
-	return c, nil
+	ctx = context.WithValue(ctx, hostConfigKey, c)
+	return ctx, c, nil
 }
 
 func (o *options) beforeProxyMiddleware(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		// get the hostmapper configurations before the request is proxied
-		c, err := o.getHostConfig(request)
+		ctx, c, err := o.getHostConfig(request.Context(), request)
 		if err != nil {
 			o.onReqError(request, err)
 			return
@@ -244,7 +243,8 @@ func (o *options) beforeProxyMiddleware(h http.Handler) http.Handler {
 		if c.CorsEnabled && c.CorsOptions != nil {
 			cors.New(*c.CorsOptions).HandlerFunc(writer, request)
 		}
-		h.ServeHTTP(writer, request)
+
+		h.ServeHTTP(writer, request.WithContext(ctx))
 	})
 }
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -52,6 +52,9 @@ type (
 		// PathPrefix is a prefix that is prepended on the original host,
 		// but removed before forwarding.
 		PathPrefix string
+		// TrustForwardedHosts is a flag that indicates whether the proxy should trust the
+		// X-Forwarded-* headers or not.
+		TrustForwardedHeaders bool
 		// originalHost the original hostname the request is coming from.
 		// This value will be maintained internally by the proxy.
 		originalHost string
@@ -100,6 +103,10 @@ func rewriter(o *options) func(*httputil.ProxyRequest) {
 		if err != nil {
 			o.onReqError(r.Out, err)
 			return
+		}
+
+		if c.TrustForwardedHeaders {
+			r.SetXForwarded()
 		}
 
 		c.setScheme(r)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -5,11 +5,10 @@ package proxy
 
 import (
 	"context"
+	"github.com/pkg/errors"
 	"log"
 	"net/http"
 	"net/http/httputil"
-
-	"github.com/pkg/errors"
 
 	"github.com/rs/cors"
 	"go.opentelemetry.io/otel"
@@ -107,6 +106,16 @@ func rewriter(o *options) func(*httputil.ProxyRequest) {
 
 		if c.TrustForwardedHeaders {
 			r.SetXForwarded()
+			headers := []string{
+				"X-Forwarded-Host",
+				"X-Forwarded-Proto",
+				"X-Forwarded-For",
+			}
+			for _, h := range headers {
+				if v := r.In.Header.Get(h); v != "" {
+					r.Out.Header.Set(h, v)
+				}
+			}
 		}
 
 		c.setScheme(r)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -105,7 +105,6 @@ func rewriter(o *options) func(*httputil.ProxyRequest) {
 		}
 
 		if c.TrustForwardedHeaders {
-			r.SetXForwarded()
 			headers := []string{
 				"X-Forwarded-Host",
 				"X-Forwarded-Proto",


### PR DESCRIPTION
Adds a feature flag to revert regressions introduced by switching to proxy.Rewrite.