### PR TITLE
feat(clidoc): enable templating for command fields

### DIFF
--- a/clidoc/generate_test.go
+++ b/clidoc/generate_test.go
@@ -24,7 +24,7 @@ root
 child1
 
 <[some argument]>
-`}
+`, Example: "{{ .CommandPath }} --whatever"}
 	child2 = &cobra.Command{Use: "child2", Run: noopRun, Long: `A sample text
 child2
 

--- a/clidoc/md_docs.go
+++ b/clidoc/md_docs.go
@@ -16,13 +16,14 @@ package clidoc
 import (
 	"bytes"
 	"fmt"
-	"github.com/ory/x/cmdx"
 	"html"
 	"io"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/ory/x/cmdx"
 
 	"github.com/spf13/cobra"
 )

--- a/clidoc/md_docs.go
+++ b/clidoc/md_docs.go
@@ -16,6 +16,7 @@ package clidoc
 import (
 	"bytes"
 	"fmt"
+	"github.com/ory/x/cmdx"
 	"html"
 	"io"
 	"os"
@@ -62,7 +63,12 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 	buf.WriteString(cmd.Short + "\n\n")
 	if len(cmd.Long) > 0 {
 		buf.WriteString("### Synopsis\n\n")
-		buf.WriteString(cmd.Long + "\n\n")
+		long, err := cmdx.TemplateCommandField(cmd, cmd.Long)
+		if err != nil {
+			buf.WriteString(fmt.Sprintf("<!-- Error rendering cmd.Long: %s -->\n\n", err.Error()))
+			long = cmd.Long
+		}
+		buf.WriteString(long + "\n\n")
 	}
 
 	if cmd.Runnable() {
@@ -71,7 +77,12 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 
 	if len(cmd.Example) > 0 {
 		buf.WriteString("### Examples\n\n")
-		buf.WriteString(fmt.Sprintf("```\n%s\n```\n\n", cmd.Example))
+		example, err := cmdx.TemplateCommandField(cmd, cmd.Example)
+		if err != nil {
+			buf.WriteString(fmt.Sprintf("<!-- Error rendering cmd.Example: %s -->\n\n", err.Error()))
+			example = cmd.Example
+		}
+		buf.WriteString(fmt.Sprintf("```\n%s\n```\n\n", example))
 	}
 
 	if err := printOptions(buf, cmd, name); err != nil {

--- a/clidoc/testdata/root-child1.md
+++ b/clidoc/testdata/root-child1.md
@@ -25,6 +25,12 @@ child1
 root child1 [flags]
 ```
 
+### Examples
+
+```
+root child1 --whatever
+```
+
 ### Options
 
 ```

--- a/cmdx/usage.go
+++ b/cmdx/usage.go
@@ -54,23 +54,25 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 // The data for the template is the command itself. Especially useful are `.Root.Name` and `.CommandPath`.
 // This will be inherited by all subcommands, so enabling it on the root command is sufficient.
 func EnableUsageTemplating(cmds ...*cobra.Command) {
-	cobra.AddTemplateFunc("insertTemplate", func(cmd *cobra.Command, tmpl string) (string, error) {
-		t := template.New("")
-		t.Funcs(usageTemplateFuncs)
-		t, err := t.Parse(tmpl)
-		if err != nil {
-			return "", err
-		}
-		var out bytes.Buffer
-		if err := t.Execute(&out, cmd); err != nil {
-			return "", err
-		}
-		return out.String(), nil
-	})
+	cobra.AddTemplateFunc("insertTemplate", TemplateCommandField)
 	for _, cmd := range cmds {
 		cmd.SetHelpTemplate(helpTemplate)
 		cmd.SetUsageTemplate(usageTemplate)
 	}
+}
+
+func TemplateCommandField(cmd *cobra.Command, field string) (string, error) {
+	t := template.New("")
+	t.Funcs(usageTemplateFuncs)
+	t, err := t.Parse(field)
+	if err != nil {
+		return "", err
+	}
+	var out bytes.Buffer
+	if err := t.Execute(&out, cmd); err != nil {
+		return "", err
+	}
+	return out.String(), nil
 }
 
 // DisableUsageTemplating resets the commands usage template to the default.


### PR DESCRIPTION
This results in the same results as we already have in the help templates. How did we not notice it until now??