### PR TITLE
feat(configx): allow exceptions in immutables

### DIFF
--- a/configx/options.go
+++ b/configx/options.go
@@ -44,6 +44,12 @@ func WithImmutables(immutables ...string) OptionModifier {
 	}
 }
 
+func WithExceptImmutables(exceptImmutables ...string) OptionModifier {
+	return func(p *Provider) {
+		p.exceptImmutables = append(p.exceptImmutables, exceptImmutables...)
+	}
+}
+
 func WithFlags(flags *pflag.FlagSet) OptionModifier {
 	return func(p *Provider) {
 		p.flags = flags

--- a/corsx/check_origin.go
+++ b/corsx/check_origin.go
@@ -1,0 +1,53 @@
+// Copyright © 2023 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package corsx
+
+import "strings"
+
+// CheckOrigin is a function that can be used well with cors.Options.AllowOriginRequestFunc.
+// It checks whether the origin is allowed following the same behavior as github.com/rs/cors.
+//
+// Recommended usage for hot-reloadable origins:
+//
+//	func (p *Config) cors(ctx context.Context, prefix string) (cors.Options, bool) {
+//		opts, enabled := p.GetProvider(ctx).CORS(prefix, cors.Options{
+//			AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE"},
+//			AllowedHeaders:   []string{"Authorization", "Content-Type", "Cookie"},
+//			ExposedHeaders:   []string{"Content-Type", "Set-Cookie"},
+//			AllowCredentials: true,
+//		})
+//		opts.AllowOriginRequestFunc = func(r *http.Request, origin string) bool {
+//			// load the origins from the config on every request to allow hot-reloading
+//			allowedOrigins := p.GetProvider(r.Context()).Strings(prefix + ".cors.allowed_origins")
+//			return corsx.CheckOrigin(allowedOrigins, origin)
+//		}
+//		return opts, enabled
+//	}
+func CheckOrigin(allowedOrigins []string, origin string) bool {
+	if len(allowedOrigins) == 0 {
+		return true
+	}
+	for _, o := range allowedOrigins {
+		if o == "*" {
+			// allow all origins
+			return true
+		}
+		// Note: for origins and methods matching, the spec requires a case-sensitive matching.
+		// As it may be error-prone, we chose to ignore the spec here.
+		// https://github.com/rs/cors/blob/066574eebbd0f5f1b6cd1154a160cc292ac1835e/cors.go#L132-L133
+		prefix, suffix, found := strings.Cut(strings.ToLower(o), "*")
+		if !found {
+			// not a pattern, check for equality
+			if o == origin {
+				return true
+			}
+			continue
+		}
+		// inspired by https://github.com/rs/cors/blob/066574eebbd0f5f1b6cd1154a160cc292ac1835e/utils.go#L15
+		if len(origin) >= len(prefix)+len(suffix) && strings.HasPrefix(origin, prefix) && strings.HasSuffix(origin, suffix) {
+			return true
+		}
+	}
+	return false
+}

--- a/corsx/check_origin.go
+++ b/corsx/check_origin.go
@@ -36,7 +36,8 @@ func CheckOrigin(allowedOrigins []string, origin string) bool {
 		// Note: for origins and methods matching, the spec requires a case-sensitive matching.
 		// As it may be error-prone, we chose to ignore the spec here.
 		// https://github.com/rs/cors/blob/066574eebbd0f5f1b6cd1154a160cc292ac1835e/cors.go#L132-L133
-		prefix, suffix, found := strings.Cut(strings.ToLower(o), "*")
+		o = strings.ToLower(o)
+		prefix, suffix, found := strings.Cut(o, "*")
 		if !found {
 			// not a pattern, check for equality
 			if o == origin {

--- a/corsx/check_origin_test.go
+++ b/corsx/check_origin_test.go
@@ -1,0 +1,111 @@
+// Copyright © 2023 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package corsx
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/rs/cors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckOrigin(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		allowedOrigins      []string
+		expect, expectOther bool
+	}{
+		{
+			name:           "empty",
+			allowedOrigins: []string{},
+			expect:         true,
+			expectOther:    true,
+		},
+		{
+			name:           "wildcard",
+			allowedOrigins: []string{"https://example.com", "*"},
+			expect:         true,
+			expectOther:    true,
+		},
+		{
+			name:           "exact",
+			allowedOrigins: []string{"https://www.ory.sh"},
+			expect:         true,
+		},
+		{
+			name:           "wildcard in the beginning",
+			allowedOrigins: []string{"*.ory.sh"},
+			expect:         true,
+		},
+		{
+			name:           "wildcard in the middle",
+			allowedOrigins: []string{"https://*.ory.sh"},
+			expect:         true,
+		},
+		{
+			name:           "wildcard in the end",
+			allowedOrigins: []string{"https://www.ory.*"},
+			expect:         true,
+		},
+		{
+			name:           "second wildcard is ignored",
+			allowedOrigins: []string{"https://*.ory.*"},
+			expect:         false,
+		},
+		{
+			name:           "multiple exact",
+			allowedOrigins: []string{"https://example.com", "https://www.ory.sh"},
+			expect:         true,
+		},
+		{
+			name:           "multiple wildcard",
+			allowedOrigins: []string{"https://*.example.com", "https://*.ory.sh"},
+			expect:         true,
+		},
+		{
+			name:           "wildcard and exact origins 1",
+			allowedOrigins: []string{"https://*.example.com", "https://www.ory.sh"},
+			expect:         true,
+		},
+		{
+			name:           "wildcard and exact origins 2",
+			allowedOrigins: []string{"https://example.com", "https://*.ory.sh"},
+			expect:         true,
+		},
+		{
+			name:           "multiple unrelated exact",
+			allowedOrigins: []string{"https://example.com", "https://example.org"},
+			expect:         false,
+		},
+		{
+			name:           "multiple unrelated with wildcard",
+			allowedOrigins: []string{"https://*.example.com", "https://*.example.org"},
+			expect:         false,
+		},
+		{
+			name:           "uppercase exact",
+			allowedOrigins: []string{"https://www.ORY.sh"},
+			expect:         true,
+		},
+		{
+			name:           "uppercase wildcard",
+			allowedOrigins: []string{"https://*.ORY.sh"},
+			expect:         true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expect, CheckOrigin(tc.allowedOrigins, "https://www.ory.sh"))
+
+			assert.Equal(t, tc.expectOther, CheckOrigin(tc.allowedOrigins, "https://google.com"))
+
+			// check for consistency with rs/cors
+			assert.Equal(t, tc.expect, cors.New(cors.Options{AllowedOrigins: tc.allowedOrigins}).
+				OriginAllowed(&http.Request{Header: http.Header{"Origin": []string{"https://www.ory.sh"}}}))
+
+			assert.Equal(t, tc.expectOther, cors.New(cors.Options{AllowedOrigins: tc.allowedOrigins}).
+				OriginAllowed(&http.Request{Header: http.Header{"Origin": []string{"https://google.com"}}}))
+		})
+	}
+}

--- a/corsx/middleware.go
+++ b/corsx/middleware.go
@@ -19,6 +19,8 @@ import (
 //	  panic("implement me")
 //	})
 //	// ...
+//
+// Deprecated: because this is not really practical to use, you should use CheckOrigin as the cors.Options.AllowOriginRequestFunc instead.
 func ContextualizedMiddleware(provider func(context.Context) (opts cors.Options, enabled bool)) negroni.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 		options, enabled := provider(r.Context())


### PR DESCRIPTION
This makes it possible to allow hot-reloading e.g. the CORS origins, while the rest of the serve key is not hot-reloadable.