### PR TITLE
feat(configx): add HTTP header log redaction config

### DIFF
--- a/configx/stub/from-files/config.schema.json
+++ b/configx/stub/from-files/config.schema.json
@@ -850,6 +850,16 @@
           "title": "Sensitive log value redaction text",
           "description": "Text to use, when redacting sensitive log value."
         },
+        "redactable_http_headers": {
+          "type": "array",
+          "title": "Redactable HTTP headers",
+          "description": "Additional HTTP headers to redact in the logs.",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["X-Auth-Token", "X-Authenticated-User"]],
+          "uniqueItems": true
+        },
         "format": {
           "type": "string",
           "enum": ["json", "text"]

--- a/configx/stub/hydra/config.schema.json
+++ b/configx/stub/hydra/config.schema.json
@@ -203,6 +203,16 @@
           "title": "Sensitive log value redaction text",
           "description": "Text to use, when redacting sensitive log value."
         },
+        "redactable_http_headers": {
+          "type": "array",
+          "title": "Redactable HTTP headers",
+          "description": "Additional HTTP headers to redact in the logs.",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["X-Auth-Token", "X-Authenticated-User"]],
+          "uniqueItems": true
+        },
         "format": {
           "type": "string",
           "description": "Sets the log format.",

--- a/configx/stub/kratos/config.schema.json
+++ b/configx/stub/kratos/config.schema.json
@@ -850,6 +850,16 @@
           "title": "Sensitive log value redaction text",
           "description": "Text to use, when redacting sensitive log value."
         },
+        "redactable_http_headers": {
+          "type": "array",
+          "title": "Redactable HTTP headers",
+          "description": "Additional HTTP headers to redact in the logs.",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["X-Auth-Token", "X-Authenticated-User"]],
+          "uniqueItems": true
+        },
         "format": {
           "type": "string",
           "enum": ["json", "text"]

--- a/configx/stub/multi/config.schema.json
+++ b/configx/stub/multi/config.schema.json
@@ -850,6 +850,16 @@
           "title": "Sensitive log value redaction text",
           "description": "Text to use, when redacting sensitive log value."
         },
+        "redactable_http_headers": {
+          "type": "array",
+          "title": "Redactable HTTP headers",
+          "description": "Additional HTTP headers to redact in the logs.",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["X-Auth-Token", "X-Authenticated-User"]],
+          "uniqueItems": true
+        },
         "format": {
           "type": "string",
           "enum": ["json", "text"]

--- a/logrusx/config.schema.json
+++ b/logrusx/config.schema.json
@@ -29,6 +29,16 @@
       "type": "string",
       "title": "Sensitive log value redaction text",
       "description": "Text to use, when redacting sensitive log value."
+    },
+    "redactable_http_headers": {
+      "type": "array",
+      "title": "Redactable HTTP headers",
+      "description": "Additional HTTP headers to redact in the logs.",
+      "items": {
+        "type": "string"
+      },
+      "examples": [["X-Auth-Token", "X-Authenticated-User"]],
+      "uniqueItems": true
     }
   },
   "additionalProperties": false

--- a/logrusx/logrus_test.go
+++ b/logrusx/logrus_test.go
@@ -136,6 +136,19 @@ func TestTextLogger(t *testing.T) {
 			},
 		},
 		{
+			l: New("logrusx-app", "v0.0.0", ForceFormat("text"), ForceLevel(logrus.TraceLevel), RedactionText("redacted"), RedactableHTTPHeaders([]string{"X-Request-ID"})),
+			expect: []string{"logrus_test.go", "logrusx_test.TestTextLogger",
+				"audience=application", "service_name=logrusx-app", "service_version=v0.0.0",
+				"An error occurred.", "headers:map[", "accept:application/json", "accept-encoding:gzip",
+				"user-agent:Go-http-client/1.1", "host:127.0.0.1:63232", "method:GET",
+				"query:redacted",
+			},
+			notExpect: []string{"testing.tRunner", "bar=foo", "x-request-id:id1234"},
+			call: func(l *Logger) {
+				l.WithRequest(fakeRequest).Error("An error occurred.")
+			},
+		},
+		{
 			l: New("logrusx-server", "v0.0.1", ForceFormat("text"), LeakSensitive(), ForceLevel(logrus.DebugLevel)),
 			expect: []string{
 				"audience=application", "service_name=logrusx-server", "service_version=v0.0.1",


### PR DESCRIPTION
This PR introduces a change that allows configuration of additional HTTP headers to be redacted in the logs to address a case where custom HTTP headers containing sensitive information (e.g. tokens) are logged on production environments when a deployment such as one for Ory Kratos triggers a webhook request with these headers

Some alternatives that were considered include:
- Setting the log level to `fatal` to keep these kind of information out of the logs, which is not really a desirable log level as it would result in decreased observability of the deployments
- Trying to place tokens inside of the `Authorization` header, which would be ideal, but some 3rd party APIs do not accept a standard `Authorization` header and instead require non-standard HTTP headers such as `X-Auth-Token` in which case it is simpler to have deployments accept such headers with redaction, rather than having some proxy rewrite the HTTP headers

## Related Issue or Design Document

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments
