### PR TITLE
fix: maintain jaeger trace b3 sampled state

### DIFF
--- a/otelx/jaeger.go
+++ b/otelx/jaeger.go
@@ -19,8 +19,8 @@ import (
 )
 
 // Optionally, Config.Providers.Jaeger.LocalAgentAddress can be set.
-// NOTE: If Config.Providers.Jaeger.Sampling.ServerURL is not specfied,
-// AlwaysSample is used.
+// NOTE: If Config.Providers.Jaeger.Sampling.ServerURL is not specified,
+// the otel spec default `ParentBased(AlwaysSample())` is used.
 func SetupJaeger(t *Tracer, tracerName string, c *Config) (trace.Tracer, error) {
 	host, port, err := net.SplitHostPort(c.Providers.Jaeger.LocalAgentAddress)
 	if err != nil {
@@ -54,7 +54,7 @@ func SetupJaeger(t *Tracer, tracerName string, c *Config) (trace.Tracer, error) 
 		)
 		tpOpts = append(tpOpts, sdktrace.WithSampler(jaegerRemoteSampler))
 	} else {
-		tpOpts = append(tpOpts, sdktrace.WithSampler(sdktrace.AlwaysSample()))
+		tpOpts = append(tpOpts, sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.AlwaysSample())))
 	}
 	tp := sdktrace.NewTracerProvider(tpOpts...)
 	otel.SetTracerProvider(tp)


### PR DESCRIPTION
`AlwaysSample()` will include spans whose parents were not sampled, which is generally unwanted as it leads to leaf nodes without parents in the telemetry graph. This change updates the jaeger setup to use the [otel spec default] `ParentBased(AlwaysSample())` which fixes this issue.

[otel spec default]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.25.0/specification/trace/sdk.md#built-in-samplers

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

This parent-based behavior was used in this repo via the [jaeger-client-go](https://github.com/jaegertracing/jaeger-client-go) library before the switch to otel as that exporter [always defers to parent span sampling decisions](https://www.jaegertracing.io/docs/1.49/sampling/).