### PR TITLE
fix: decoderx dropped errors

### DIFF
--- a/decoderx/http.go
+++ b/decoderx/http.go
@@ -399,8 +399,6 @@ func (t *HTTP) decodeForm(r *http.Request, destination interface{}, o *httpDecod
 }
 
 func (t *HTTP) decodeURLValues(values url.Values, paths []jsonschemax.Path, o *httpDecoderOptions) (json.RawMessage, error) {
-	var f float64
-	var b bool
 	raw := json.RawMessage(`{}`)
 	for key := range values {
 		for _, path := range paths {
@@ -411,6 +409,7 @@ func (t *HTTP) decodeURLValues(values url.Values, paths []jsonschemax.Path, o *h
 					raw, err = sjson.SetBytes(raw, path.Name, values[key])
 				case []float64:
 					for k, v := range values[key] {
+						var f float64
 						if f, err = strconv.ParseFloat(v, 64); err != nil {
 							switch o.handleParseErrors {
 							case ParseErrorIgnoreConversionErrors:
@@ -430,6 +429,7 @@ func (t *HTTP) decodeURLValues(values url.Values, paths []jsonschemax.Path, o *h
 					}
 				case []bool:
 					for k, v := range values[key] {
+						var b bool
 						if b, err = strconv.ParseBool(v); err != nil {
 							switch o.handleParseErrors {
 							case ParseErrorIgnoreConversionErrors:
@@ -458,6 +458,7 @@ func (t *HTTP) decodeURLValues(values url.Values, paths []jsonschemax.Path, o *h
 						v = "false"
 					}
 
+					var b bool
 					if b, err = strconv.ParseBool(v); err != nil {
 						switch o.handleParseErrors {
 						case ParseErrorIgnoreConversionErrors:
@@ -482,6 +483,7 @@ func (t *HTTP) decodeURLValues(values url.Values, paths []jsonschemax.Path, o *h
 						v = "0.0"
 					}
 
+					var f float64
 					if f, err = strconv.ParseFloat(v, 64); err != nil {
 						switch o.handleParseErrors {
 						case ParseErrorIgnoreConversionErrors:

--- a/decoderx/http.go
+++ b/decoderx/http.go
@@ -399,6 +399,8 @@ func (t *HTTP) decodeForm(r *http.Request, destination interface{}, o *httpDecod
 }
 
 func (t *HTTP) decodeURLValues(values url.Values, paths []jsonschemax.Path, o *httpDecoderOptions) (json.RawMessage, error) {
+	var f float64
+	var b bool
 	raw := json.RawMessage(`{}`)
 	for key := range values {
 		for _, path := range paths {
@@ -409,7 +411,7 @@ func (t *HTTP) decodeURLValues(values url.Values, paths []jsonschemax.Path, o *h
 					raw, err = sjson.SetBytes(raw, path.Name, values[key])
 				case []float64:
 					for k, v := range values[key] {
-						if f, err := strconv.ParseFloat(v, 64); err != nil {
+						if f, err = strconv.ParseFloat(v, 64); err != nil {
 							switch o.handleParseErrors {
 							case ParseErrorIgnoreConversionErrors:
 								raw, err = sjson.SetBytes(raw, path.Name+"."+strconv.Itoa(k), v)
@@ -428,12 +430,12 @@ func (t *HTTP) decodeURLValues(values url.Values, paths []jsonschemax.Path, o *h
 					}
 				case []bool:
 					for k, v := range values[key] {
-						if f, err := strconv.ParseBool(v); err != nil {
+						if b, err = strconv.ParseBool(v); err != nil {
 							switch o.handleParseErrors {
 							case ParseErrorIgnoreConversionErrors:
 								raw, err = sjson.SetBytes(raw, path.Name+"."+strconv.Itoa(k), v)
 							case ParseErrorUseEmptyValueOnConversionErrors:
-								raw, err = sjson.SetBytes(raw, path.Name+"."+strconv.Itoa(k), f)
+								raw, err = sjson.SetBytes(raw, path.Name+"."+strconv.Itoa(k), b)
 							case ParseErrorReturnOnConversionErrors:
 								return nil, errors.WithStack(herodot.ErrBadRequest.WithReasonf("Expected value to be a boolean.").
 									WithDetail("parse_error", err.Error()).
@@ -442,7 +444,7 @@ func (t *HTTP) decodeURLValues(values url.Values, paths []jsonschemax.Path, o *h
 									WithDetail("value", v))
 							}
 						} else {
-							raw, err = sjson.SetBytes(raw, path.Name+"."+strconv.Itoa(k), f)
+							raw, err = sjson.SetBytes(raw, path.Name+"."+strconv.Itoa(k), b)
 						}
 					}
 				case []interface{}:
@@ -456,12 +458,12 @@ func (t *HTTP) decodeURLValues(values url.Values, paths []jsonschemax.Path, o *h
 						v = "false"
 					}
 
-					if f, err := strconv.ParseBool(v); err != nil {
+					if b, err = strconv.ParseBool(v); err != nil {
 						switch o.handleParseErrors {
 						case ParseErrorIgnoreConversionErrors:
 							raw, err = sjson.SetBytes(raw, path.Name, v)
 						case ParseErrorUseEmptyValueOnConversionErrors:
-							raw, err = sjson.SetBytes(raw, path.Name, f)
+							raw, err = sjson.SetBytes(raw, path.Name, b)
 						case ParseErrorReturnOnConversionErrors:
 							return nil, errors.WithStack(herodot.ErrBadRequest.WithReasonf("Expected value to be a boolean.").
 								WithDetail("parse_error", err.Error()).
@@ -469,7 +471,7 @@ func (t *HTTP) decodeURLValues(values url.Values, paths []jsonschemax.Path, o *h
 								WithDetail("value", values.Get(key)))
 						}
 					} else {
-						raw, err = sjson.SetBytes(raw, path.Name, f)
+						raw, err = sjson.SetBytes(raw, path.Name, b)
 					}
 				case float64:
 					v := values.Get(key)
@@ -480,7 +482,7 @@ func (t *HTTP) decodeURLValues(values url.Values, paths []jsonschemax.Path, o *h
 						v = "0.0"
 					}
 
-					if f, err := strconv.ParseFloat(v, 64); err != nil {
+					if f, err = strconv.ParseFloat(v, 64); err != nil {
 						switch o.handleParseErrors {
 						case ParseErrorIgnoreConversionErrors:
 							raw, err = sjson.SetBytes(raw, path.Name, v)


### PR DESCRIPTION
This fixes 12 `err` variables in the `decoderx` package that are being dropped due to the use of `:=` in single-line `if x, err := func(y); err != nil` statements.