### PR TITLE
feat: add http client option to disable IPv6

### DIFF
--- a/httpx/resilient_client_test.go
+++ b/httpx/resilient_client_test.go
@@ -4,12 +4,17 @@
 package httpx
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httptrace"
+	"net/netip"
 	"net/url"
+	"sync/atomic"
 	"testing"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -53,5 +58,73 @@ func TestNoPrivateIPs(t *testing.T) {
 				require.NoErrorf(t, err, "dest = %s", destination)
 			}
 		}
+	}
+}
+
+func TestNoIPV6(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		c    *retryablehttp.Client
+	}{
+		{
+			"internal IPs allowed",
+			NewResilientClient(
+				ResilientClientWithMaxRetry(1),
+				ResilientClientNoIPv6(),
+			),
+		}, {
+			"internal IPs disallowed",
+			NewResilientClient(
+				ResilientClientWithMaxRetry(1),
+				ResilientClientDisallowInternalIPs(),
+				ResilientClientNoIPv6(),
+			),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var connectDone int32
+			ctx := httptrace.WithClientTrace(context.Background(), &httptrace.ClientTrace{
+				DNSDone: func(dnsInfo httptrace.DNSDoneInfo) {
+					for _, ip := range dnsInfo.Addrs {
+						netIP, ok := netip.AddrFromSlice(ip.IP)
+						assert.True(t, ok)
+						assert.Truef(t, netIP.Is4(), "ip = %s", ip)
+					}
+				},
+				ConnectDone: func(network, addr string, err error) {
+					atomic.AddInt32(&connectDone, 1)
+					assert.NoError(t, err)
+					assert.Equalf(t, "tcp4", network, "network = %s addr = %s", network, addr)
+				},
+			})
+
+			// Dual stack
+			req, err := retryablehttp.NewRequestWithContext(ctx, "GET", "http://dual.tlund.se/", nil)
+			require.NoError(t, err)
+			atomic.StoreInt32(&connectDone, 0)
+			res, err := tc.c.Do(req)
+			require.GreaterOrEqual(t, int32(1), atomic.LoadInt32(&connectDone))
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = res.Body.Close() })
+			require.EqualValues(t, http.StatusOK, res.StatusCode)
+
+			// IPv4 only
+			req, err = retryablehttp.NewRequestWithContext(ctx, "GET", "http://ipv4.tlund.se/", nil)
+			require.NoError(t, err)
+			atomic.StoreInt32(&connectDone, 0)
+			res, err = tc.c.Do(req)
+			require.EqualValues(t, 1, atomic.LoadInt32(&connectDone))
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = res.Body.Close() })
+			require.EqualValues(t, http.StatusOK, res.StatusCode)
+
+			// IPv6 only
+			req, err = retryablehttp.NewRequestWithContext(ctx, "GET", "http://ipv6.tlund.se/", nil)
+			require.NoError(t, err)
+			atomic.StoreInt32(&connectDone, 0)
+			_, err = tc.c.Do(req)
+			require.EqualValues(t, 0, atomic.LoadInt32(&connectDone))
+			require.ErrorContains(t, err, "no such host")
+		})
 	}
 }

--- a/jsonnetsecure/jsonnet_pool.go
+++ b/jsonnetsecure/jsonnet_pool.go
@@ -156,7 +156,8 @@ func (w worker) destroy() {
 
 func (w worker) eval(ctx context.Context, processParams []byte) (output string, err error) {
 	tracer := trace.SpanFromContext(ctx).TracerProvider().Tracer("")
-	ctx, span := tracer.Start(ctx, "jsonnetsecure.worker.eval")
+	ctx, span := tracer.Start(ctx, "jsonnetsecure.worker.eval",
+		trace.WithAttributes(attribute.Int("cmd.Process.Pid", w.cmd.Process.Pid)))
 	defer otelx.End(span, &err)
 
 	select {


### PR DESCRIPTION
* improve connection re-use
* add detailed trace events (DNS, TLS, etc)

Looks like this in Tempo: left is a newly established connection, right is a reused connection.

<img width="1907" alt="image" src="https://github.com/ory/x/assets/3969502/d79a1364-27f3-4b06-90cc-a48750c3dccb">
