### PR TITLE
fix: occasional jsonnet timeouts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.55.2
+          version: v1.59.1
           skip-go-installation: true
           args: --timeout 5m
       - name: Install cockroach DB

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,9 @@
 linters:
   enable:
     - gosec
-    - vet
+    - govet
   disable-all: true
 
 run:
   skip-files:
-    - "migrate_files.go" # go-bindata
     - ".+_test.go"

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ licenses: .bin/licenses node_modules  # checks open-source licenses
 	GOBIN=$(shell pwd)/.bin go install golang.org/x/tools/cmd/goimports@latest
 
 .bin/golangci-lint: Makefile
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b .bin v1.55.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b .bin v1.59.1
 
 .bin/licenses: Makefile
 	curl https://raw.githubusercontent.com/ory/ci/master/licenses/install | sh

--- a/cmdx/http.go
+++ b/cmdx/http.go
@@ -109,9 +109,8 @@ func NewClient(cmd *cobra.Command) (*http.Client, *url.URL, error) {
 
 	rt := httpx.NewTransportWithHeader(header)
 	rt.RoundTripper = &http.Transport{
-		//#nosec G402 -- This is a false positive
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: skipVerify,
+			InsecureSkipVerify: skipVerify, //nolint:gosec // This is a false positive
 		},
 	}
 	hc.Transport = rt

--- a/httpx/gzip_server.go
+++ b/httpx/gzip_server.go
@@ -41,8 +41,7 @@ func (c *CompressionRequestReader) ServeHTTP(w http.ResponseWriter, r *http.Requ
 				return
 			}
 
-			/* #nosec G110 - FIXME */
-			if _, err := io.Copy(&b, reader); err != nil {
+			if _, err := io.Copy(&b, reader); err != nil { //nolint:gosec // FIXME
 				c.ErrHandler(w, r, err)
 				return
 			}

--- a/jsonnetsecure/jsonnet.go
+++ b/jsonnetsecure/jsonnet.go
@@ -9,18 +9,11 @@ import (
 	"path"
 	"runtime"
 	"testing"
-	"time"
 
 	"github.com/google/go-jsonnet"
 )
 
 type (
-	evaluationOptions struct {
-		evalTimeout time.Duration
-	}
-
-	EvaluationOptionModifier func(*evaluationOptions)
-
 	VM interface {
 		EvaluateAnonymousSnippet(filename string, snippet string) (json string, formattedErr error)
 		ExtCode(key string, val string)
@@ -38,11 +31,10 @@ type (
 	}
 
 	ProcessVM struct {
-		ctx         context.Context
-		path        string
-		args        []string
-		execTimeout time.Duration
-		params      processParameters
+		ctx    context.Context
+		path   string
+		args   []string
+		params processParameters
 	}
 
 	vmOptions struct {
@@ -51,7 +43,6 @@ type (
 		args              []string
 		ctx               context.Context
 		pool              *pool
-		execTimeout       time.Duration
 	}
 
 	Option func(o *vmOptions)
@@ -76,12 +67,6 @@ func WithProcessIsolatedVM(ctx context.Context) Option {
 	return func(o *vmOptions) {
 		o.useProcessVM = true
 		o.ctx = ctx
-	}
-}
-
-func WithExecTimeout(timeout time.Duration) Option {
-	return func(o *vmOptions) {
-		o.execTimeout = timeout
 	}
 }
 

--- a/jsonnetsecure/jsonnet_pool.go
+++ b/jsonnetsecure/jsonnet_pool.go
@@ -5,7 +5,6 @@ package jsonnetsecure
 
 import (
 	"bufio"
-	"cmp"
 	"context"
 	"encoding/json"
 	"io"
@@ -24,12 +23,11 @@ import (
 
 type (
 	processPoolVM struct {
-		path        string
-		args        []string
-		ctx         context.Context
-		params      processParameters
-		execTimeout time.Duration
-		pool        *pool
+		path   string
+		args   []string
+		ctx    context.Context
+		params processParameters
+		pool   *pool
 	}
 	Pool interface {
 		Close()
@@ -185,7 +183,7 @@ func (vm *processPoolVM) EvaluateAnonymousSnippet(filename string, snippet strin
 	defer otelx.End(span, &err)
 
 	// TODO: maybe leave the timeout to the caller?
-	ctx, cancel := context.WithTimeout(ctx, cmp.Or(vm.execTimeout, 1*time.Second))
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 
 	params := vm.params
@@ -224,11 +222,10 @@ func NewProcessPoolVM(opts *vmOptions) VM {
 		ctx = context.Background()
 	}
 	return &processPoolVM{
-		path:        opts.jsonnetBinaryPath,
-		args:        opts.args,
-		ctx:         ctx,
-		pool:        opts.pool,
-		execTimeout: opts.execTimeout,
+		path: opts.jsonnetBinaryPath,
+		args: opts.args,
+		ctx:  ctx,
+		pool: opts.pool,
 	}
 }
 

--- a/jsonnetsecure/jsonnet_processvm.go
+++ b/jsonnetsecure/jsonnet_processvm.go
@@ -5,7 +5,6 @@ package jsonnetsecure
 
 import (
 	"bytes"
-	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -24,10 +23,9 @@ import (
 
 func NewProcessVM(opts *vmOptions) VM {
 	return &ProcessVM{
-		path:        opts.jsonnetBinaryPath,
-		args:        opts.args,
-		ctx:         opts.ctx,
-		execTimeout: opts.execTimeout,
+		path: opts.jsonnetBinaryPath,
+		args: opts.args,
+		ctx:  opts.ctx,
 	}
 }
 
@@ -37,11 +35,12 @@ func (p *ProcessVM) EvaluateAnonymousSnippet(filename string, snippet string) (_
 	defer otelx.End(span, &err)
 
 	// We retry the process creation, because it sometimes times out.
+	const processVMTimeout = 1 * time.Second
 	return backoff.RetryWithData(func() (_ string, err error) {
 		ctx, span := tracer.Start(ctx, "jsonnetsecure.ProcessVM.EvaluateAnonymousSnippet.run")
 		defer otelx.End(span, &err)
 
-		ctx, cancel := context.WithTimeout(ctx, cmp.Or(p.execTimeout, 1*time.Second))
+		ctx, cancel := context.WithTimeout(ctx, processVMTimeout)
 		defer cancel()
 
 		var (

--- a/jsonnetsecure/provider.go
+++ b/jsonnetsecure/provider.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"runtime"
 	"testing"
-	"time"
 )
 
 type (
@@ -45,7 +44,6 @@ func (p *TestProvider) JsonnetVM(ctx context.Context) (VM, error) {
 		WithProcessIsolatedVM(ctx),
 		WithProcessPool(p.pool),
 		WithJsonnetBinary(p.jsonnetBinary),
-		WithExecTimeout(time.Second*5),
 	), nil
 }
 


### PR DESCRIPTION
Reverts #798 and #799 

The fixed 1 second timeout now only applies to the Jsonnet evaluation step,
but not the the spawning of the process which can occasionally take longer.

Additionally, we now warm the pool asynchronously on construction.
