### PR TITLE
fix: migrator should skip down migrations that were not yet applied

### DIFF
--- a/popx/migrator.go
+++ b/popx/migrator.go
@@ -210,6 +210,10 @@ func (m *Migrator) Down(ctx context.Context, steps int) error {
 		steps = min(steps, count)
 
 		mfs := m.Migrations["down"].SortAndFilter(c.Dialect.Name(), sort.Reverse)
+		if len(mfs) > count {
+			// skip all migrations that were not yet applied
+			mfs = mfs[len(mfs)-count:]
+		}
 
 		reverted := 0
 		defer func() {


### PR DESCRIPTION
This reverts a part of #762 where it was incorrectly removed.