### PR TITLE
fix(otelx): always set error in `End`

### DIFF
--- a/otelx/withspan.go
+++ b/otelx/withspan.go
@@ -90,4 +90,5 @@ func setErrorTags(span trace.Span, err error) {
 			span.SetAttributes(attribute.String("error.details."+k, fmt.Sprintf("%v", v)))
 		}
 	}
+	span.SetAttributes(attribute.String("error", err.Error()))
 }


### PR DESCRIPTION
Without this change, a non-herodot error does not add any details to the trace, but only sets the status to error. It is super hard to debug then.