### PR TITLE
fix: allow calling internal IP range 100.64.0.0/10 with relevant ResilientClient options

### DIFF
--- a/httpx/ssrf.go
+++ b/httpx/ssrf.go
@@ -86,6 +86,7 @@ func init() {
 		ssrf.WithNetworks("tcp4", "tcp6"),
 		ssrf.WithAllowedV4Prefixes(
 			netip.MustParsePrefix("10.0.0.0/8"),     // Private-Use (RFC 1918)
+			netip.MustParsePrefix("100.64.0.0/10"),  // Shared Address Space (RFC 6598)
 			netip.MustParsePrefix("127.0.0.0/8"),    // Loopback (RFC 1122, Section 3.2.1.3))
 			netip.MustParsePrefix("169.254.0.0/16"), // Link Local (RFC 3927)
 			netip.MustParsePrefix("172.16.0.0/12"),  // Private-Use (RFC 1918)
@@ -106,6 +107,7 @@ func init() {
 		ssrf.WithNetworks("tcp4"),
 		ssrf.WithAllowedV4Prefixes(
 			netip.MustParsePrefix("10.0.0.0/8"),     // Private-Use (RFC 1918)
+			netip.MustParsePrefix("100.64.0.0/10"),  // Shared Address Space (RFC 6598)
 			netip.MustParsePrefix("127.0.0.0/8"),    // Loopback (RFC 1122, Section 3.2.1.3))
 			netip.MustParsePrefix("169.254.0.0/16"), // Link Local (RFC 3927)
 			netip.MustParsePrefix("172.16.0.0/12"),  // Private-Use (RFC 1918)


### PR DESCRIPTION
The `ResilientClient` options `ResilientClientDisallowInternalIPs` and `ResilientClientAllowInternalIPRequestsTo` were not allowing to call certain IP ranges, like 100.64.0.0/10 properly.


## Related Issue or Design Document

Fixes: https://github.com/ory/x/issues/805

And relates to Kratos issue: https://github.com/ory/kratos/issues/4049

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
