### PR TITLE
fix(pagination): always enforce max size is set

### DIFF
--- a/pagination/keysetpagination/paginator.go
+++ b/pagination/keysetpagination/paginator.go
@@ -34,6 +34,9 @@ var ErrUnknownOrder = errors.New("unknown order")
 const (
 	OrderDescending Order = "DESC"
 	OrderAscending  Order = "ASC"
+
+	DefaultSize    = 100
+	DefaultMaxSize = 500
 )
 
 func (o Order) extract() (string, string, error) {
@@ -62,7 +65,7 @@ func (p *Paginator) Size() int {
 			size = 100
 		}
 	}
-	if p.maxSize > 0 && size > p.maxSize {
+	if size > p.maxSize {
 		size = p.maxSize
 	}
 	return size
@@ -229,7 +232,11 @@ func withIsLast(isLast bool) Option {
 }
 
 func GetPaginator(modifiers ...Option) *Paginator {
-	opts := &Paginator{}
+	opts := &Paginator{
+		// these can still be overridden by the modifiers, but they should never be unset
+		maxSize:     DefaultMaxSize,
+		defaultSize: DefaultSize,
+	}
 	for _, f := range modifiers {
 		opts = f(opts)
 	}

--- a/pagination/keysetpagination/paginator_test.go
+++ b/pagination/keysetpagination/paginator_test.go
@@ -87,6 +87,11 @@ func TestPaginator(t *testing.T) {
 				expectedSize: 100,
 			},
 			{
+				name:         "default max size",
+				opts:         []Option{WithSize(1000)},
+				expectedSize: DefaultMaxSize,
+			},
+			{
 				name:          "with size and token",
 				opts:          []Option{WithSize(10), WithToken(StringPageToken("token"))},
 				expectedSize:  10,


### PR DESCRIPTION
We probably never want an unbound pagination. The specific implementation can still override the max page size.