### PR TITLE
fix: build on 32-bit architectures

### DIFF
--- a/hasherx/hash_comparator.go
+++ b/hasherx/hash_comparator.go
@@ -164,7 +164,7 @@ func decodeArgon2idHash(encodedHash string) (p *Argon2Config, salt, hash []byte,
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	saltLength := len(salt)
+	saltLength := uint(len(salt))
 	if saltLength > math.MaxUint32 {
 		return nil, nil, nil, ErrInvalidHash
 	}
@@ -174,7 +174,7 @@ func decodeArgon2idHash(encodedHash string) (p *Argon2Config, salt, hash []byte,
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	keyLength := len(hash)
+	keyLength := uint(len(hash))
 	if keyLength > math.MaxUint32 {
 		return nil, nil, nil, ErrInvalidHash
 	}
@@ -207,7 +207,7 @@ func decodePbkdf2Hash(encodedHash string) (p *PBKDF2Config, salt, hash []byte, e
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	saltLength := len(salt)
+	saltLength := uint(len(salt))
 	if saltLength > math.MaxUint32 {
 		return nil, nil, nil, ErrInvalidHash
 	}
@@ -217,7 +217,7 @@ func decodePbkdf2Hash(encodedHash string) (p *PBKDF2Config, salt, hash []byte, e
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	keyLength := len(hash)
+	keyLength := uint(len(hash))
 	if keyLength > math.MaxUint32 {
 		return nil, nil, nil, ErrInvalidHash
 	}

--- a/mapx/type_assert.go
+++ b/mapx/type_assert.go
@@ -97,10 +97,11 @@ func GetInt64[K comparable](values map[K]any, key K) (int64, error) {
 	case int32:
 		return int64(v), nil
 	case uint:
-		if v > math.MaxInt64 {
+		vv := uint64(v)
+		if vv > math.MaxInt64 {
 			return 0, errors.New("value is out of range")
 		}
-		return int64(v), nil
+		return int64(vv), nil
 	case uint32:
 		return int64(v), nil
 	case uint64:


### PR DESCRIPTION
The implicit type conversions of untyped ints did overflow on 32-bit int sized architectures.

```
failed to build for linux_arm_6: exit status 1: # github.com/ory/x/hasherx
Error: /go/pkg/mod/github.com/ory/x@v0.0.665/hasherx/hash_comparator.go:168:18: math.MaxUint32 (untyped int constant 4294967295) overflows int
Error: /go/pkg/mod/github.com/ory/x@v0.0.665/hasherx/hash_comparator.go:178:17: math.MaxUint32 (untyped int constant 4294967295) overflows int
Error: /go/pkg/mod/github.com/ory/x@v0.0.665/hasherx/hash_comparator.go:211:18: math.MaxUint32 (untyped int constant 4294967295) overflows int
Error: /go/pkg/mod/github.com/ory/x@v0.0.665/hasherx/hash_comparator.go:221:17: math.MaxUint32 (untyped int constant 4294967295) overflows int
# github.com/ory/x/mapx
Error: /go/pkg/mod/github.com/ory/x@v0.0.665/mapx/type_assert.go:100:10: math.MaxInt64 (untyped int constant 9223372036854775807) overflows uint
```