### PR TITLE
fix: don't leak goroutines if there are no files to watch

### DIFF
--- a/configx/provider.go
+++ b/configx/provider.go
@@ -142,8 +142,12 @@ func (p *Provider) createProviders(ctx context.Context) (providers []koanf.Provi
 	p.logger.WithField("files", paths).Debug("Adding config files.")
 
 	c := make(watcherx.EventChannel)
-	go p.watchForFileChanges(ctx, c)
 
+	defer func() {
+		if err == nil && len(paths) > 0 {
+			go p.watchForFileChanges(ctx, c)
+		}
+	}()
 	for _, path := range paths {
 		fp, err := NewKoanfFile(path)
 		if err != nil {

--- a/configx/provider_watch_test.go
+++ b/configx/provider_watch_test.go
@@ -49,11 +49,11 @@ func assertNoOpenFDs(t require.TestingT, dir, name string) {
 	}
 	var b, be bytes.Buffer
 	// we are only interested in the file descriptors, so we use the `-F f` option
-	c := exec.Command("lsof", "-n", "-F", "f", filepath.Join(dir, name))
+	c := exec.Command("lsof", "-n", "-F", "f", "--", filepath.Join(dir, name))
 	c.Stdout = &b
 	c.Stderr = &be
 	exitErr := new(exec.ExitError)
-	require.ErrorAs(t, c.Run(), &exitErr, "got stout: %s\nstderr: %s", b.String(), be.String())
+	require.ErrorAsf(t, c.Run(), &exitErr, "File %q has open file descriptor.\nGot stout: %s\nstderr: %s", filepath.Join(dir, name), b.String(), be.String())
 	assert.Equal(t, 1, exitErr.ExitCode(), "got stout: %s\nstderr: %s", b.String(), be.String())
 }
 


### PR DESCRIPTION
This fixes an issue where we were leaking many goroutines especially during tests, even though there are no files to watch.

Those goroutines are cancelable via the context passed in, but we rarely do that in test code. And if we do, we spawn literally thousands of goroutines before doing one big cancel at the end.

IMO, this whole watching code should either go away or be refactored so it is more obvious that it spawns background goroutines.