### PR TITLE
feat: add more error info to traces

### DIFF
--- a/otelx/withspan.go
+++ b/otelx/withspan.go
@@ -7,9 +7,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 
+	pkgerrors "github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -41,7 +44,7 @@ func WithSpan(ctx context.Context, name string, f func(context.Context) error, o
 // Usage:
 //
 //	func Divide(ctx context.Context, numerator, denominator int) (ratio int, err error) {
-//		ctx, span := tracer.Start(ctx, "my-operation")
+//		ctx, span := tracer.Start(ctx, "Divide")
 //		defer otelx.End(span, &err)
 //		if denominator == 0 {
 //			return 0, errors.New("cannot divide by zero")
@@ -62,6 +65,10 @@ func End(span trace.Span, err *error) {
 }
 
 func setErrorStatusPanic(span trace.Span, recovered any) {
+	span.SetAttributes(semconv.ExceptionEscaped(true))
+	if t := reflect.TypeOf(recovered); t != nil {
+		span.SetAttributes(semconv.ExceptionType(t.String()))
+	}
 	switch e := recovered.(type) {
 	case error:
 		span.SetStatus(codes.Error, "panic: "+e.Error())
@@ -76,6 +83,14 @@ func setErrorStatusPanic(span trace.Span, recovered any) {
 }
 
 func setErrorTags(span trace.Span, err error) {
+	span.SetAttributes(
+		attribute.String("error", err.Error()),
+		attribute.String("error.message", err.Error()),                        // compat
+		attribute.String("error.type", fmt.Sprintf("%T", errors.Unwrap(err))), // the innermost error type is the most useful here
+	)
+	if e := interface{ StackTrace() pkgerrors.StackTrace }(nil); errors.As(err, &e) {
+		span.SetAttributes(attribute.String("error.stack", fmt.Sprintf("%+v", e.StackTrace())))
+	}
 	if e := interface{ Reason() string }(nil); errors.As(err, &e) {
 		span.SetAttributes(attribute.String("error.reason", e.Reason()))
 	}
@@ -90,5 +105,4 @@ func setErrorTags(span trace.Span, err error) {
 			span.SetAttributes(attribute.String("error.details."+k, fmt.Sprintf("%v", v)))
 		}
 	}
-	span.SetAttributes(attribute.String("error", err.Error()))
 }


### PR DESCRIPTION
This is mostly for better Datadog compatibility. Datadog does not natively implement OpenTelemetry and its conventions, so there is a certain amount of impedance mismatching. Datadog also does not document properly where certain error info needs to be stored within a span to show up correctly in their UI. This is my best guess from the docs scattered around their website.

We might have to iterate on this.