### PR TITLE
feat: add AlphaNumNoAmbiguous rune set to randx

### DIFF
--- a/randx/sequence.go
+++ b/randx/sequence.go
@@ -29,6 +29,8 @@ var (
 	AlphaUpper = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	// Numeric contains runes [0123456789].
 	Numeric = []rune("0123456789")
+	// AlphaNumNoAmbiguous is equivalent to AlphaNum but without visually ambiguous characters [0Oo1IlB8S5Z2].
+	AlphaNumNoAmbiguous = []rune("abcdefghijkmnpqrstuvwxyzACDEFGHJKLMNPQRTUVWXY34679")
 )
 
 // RuneSequence returns a random sequence using the defined allowed runes.


### PR DESCRIPTION
The visually ambiguous characters were suggested by ChatGPT.

https://chatgpt.com/share/67979762-832c-800e-8ccf-8a0c1d3b0ce0