### PR TITLE
chore(popx): change log level for migrator logs

### DIFF
--- a/popx/migrator.go
+++ b/popx/migrator.go
@@ -174,9 +174,9 @@ func (m *Migrator) UpTo(ctx context.Context, step int) (applied int, err error) 
 			}
 		}
 		if applied == 0 {
-			m.l.Debugf("Migrations already up to date, nothing to apply")
+			m.l.Infof("Migrations already up to date, nothing to apply")
 		} else {
-			m.l.Debugf("Successfully applied %d migrations.", applied)
+			m.l.Infof("Successfully applied %d migrations.", applied)
 		}
 		return nil
 	})


### PR DESCRIPTION
Information about the number of applied migrations is very useful in case someone needs to perform a revert (down migration). It should be exposed in the logs when the default log level is set.