### PR TITLE
feat(tlsx): add validation for TLS termination

### DIFF
--- a/logrusx/helper.go
+++ b/logrusx/helper.go
@@ -23,14 +23,19 @@ import (
 	"github.com/ory/x/errorsx"
 )
 
-type Logger struct {
-	*logrus.Entry
-	leakSensitive bool
-	redactionText string
-	opts          []Option
-	name          string
-	version       string
-}
+type (
+	Logger struct {
+		*logrus.Entry
+		leakSensitive bool
+		redactionText string
+		opts          []Option
+		name          string
+		version       string
+	}
+	Provider interface {
+		Logger() *Logger
+	}
+)
 
 var opts = otelhttptrace.WithPropagators(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 

--- a/prometheusx/handler.go
+++ b/prometheusx/handler.go
@@ -1,7 +1,7 @@
 // Copyright © 2023 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 
-package prometheus
+package prometheusx
 
 import (
 	"net/http"

--- a/prometheusx/handler_test.go
+++ b/prometheusx/handler_test.go
@@ -1,7 +1,7 @@
 // Copyright © 2023 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 
-package prometheus_test
+package prometheusx_test
 
 import (
 	"net/http"

--- a/prometheusx/metrics.go
+++ b/prometheusx/metrics.go
@@ -1,7 +1,7 @@
 // Copyright © 2023 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 
-package prometheus
+package prometheusx
 
 import (
 	"net/http"

--- a/prometheusx/metrics_test.go
+++ b/prometheusx/metrics_test.go
@@ -1,7 +1,7 @@
 // Copyright © 2023 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 
-package prometheus_test
+package prometheusx_test
 
 import (
 	"context"

--- a/prometheusx/middleware.go
+++ b/prometheusx/middleware.go
@@ -1,7 +1,7 @@
 // Copyright © 2023 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 
-package prometheus
+package prometheusx
 
 import (
 	"net/http"

--- a/prometheusx/middleware_test.go
+++ b/prometheusx/middleware_test.go
@@ -1,7 +1,7 @@
 // Copyright © 2023 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 
-package prometheus
+package prometheusx
 
 import (
 	"fmt"

--- a/tlsx/termination.go
+++ b/tlsx/termination.go
@@ -1,3 +1,6 @@
+// Copyright © 2025 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
 package tlsx
 
 import (

--- a/tlsx/termination.go
+++ b/tlsx/termination.go
@@ -1,0 +1,87 @@
+package tlsx
+
+import (
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/urfave/negroni"
+
+	"github.com/ory/herodot"
+	"github.com/ory/x/healthx"
+	"github.com/ory/x/logrusx"
+	"github.com/ory/x/prometheusx"
+)
+
+func MatchesRange(r *http.Request, ranges []string) error {
+	remoteIP, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	xff := strings.Split(r.Header.Get("X-Forwarded-For"), ",")
+	check := make([]string, 1, len(xff)+1)
+	check[0] = remoteIP
+	for _, fwd := range xff {
+		check = append(check, strings.TrimSpace(fwd))
+	}
+
+	for _, rn := range ranges {
+		_, cidr, err := net.ParseCIDR(rn)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		for _, ip := range check {
+			addr := net.ParseIP(ip)
+			if cidr.Contains(addr) {
+				return nil
+			}
+		}
+	}
+	return errors.Errorf("neither remote address nor any x-forwarded-for values match CIDR ranges %v: %v, ranges, check)", ranges, check)
+}
+
+type dependencies interface {
+	logrusx.Provider
+	Writer() herodot.Writer
+}
+
+func RejectInsecureRequests(d dependencies, enabled bool, allowTerminationFrom []string) negroni.Handler {
+	return negroni.HandlerFunc(func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+		if r.TLS != nil ||
+			!enabled ||
+			r.URL.Path == healthx.AliveCheckPath ||
+			r.URL.Path == healthx.ReadyCheckPath ||
+			r.URL.Path == prometheusx.MetricsPrometheusPath {
+			next(rw, r)
+			return
+		}
+
+		if len(allowTerminationFrom) == 0 {
+			d.Logger().WithRequest(r).WithError(errors.New("TLS termination is not enabled")).Error("Could not serve http connection")
+			d.Writer().WriteErrorCode(rw, r, http.StatusBadGateway, errors.New("can not serve request over insecure http"))
+			return
+		}
+
+		if err := MatchesRange(r, allowTerminationFrom); err != nil {
+			d.Logger().WithRequest(r).WithError(err).Warnln("Could not serve http connection")
+			d.Writer().WriteErrorCode(rw, r, http.StatusBadGateway, errors.New("can not serve request over insecure http"))
+			return
+		}
+
+		proto := r.Header.Get("X-Forwarded-Proto")
+		if proto == "" {
+			d.Logger().WithRequest(r).WithError(errors.New("X-Forwarded-Proto header is missing")).Error("Could not serve http connection")
+			d.Writer().WriteErrorCode(rw, r, http.StatusBadGateway, errors.New("can not serve request over insecure http"))
+			return
+		} else if proto != "https" {
+			d.Logger().WithRequest(r).WithError(errors.New("X-Forwarded-Proto header is missing")).Error("Could not serve http connection")
+			d.Writer().WriteErrorCode(rw, r, http.StatusBadGateway, errors.Errorf("expected X-Forwarded-Proto header to be https but got: %s", proto))
+			return
+		}
+
+		next(rw, r)
+	})
+}

--- a/tlsx/termination.go
+++ b/tlsx/termination.go
@@ -51,10 +51,13 @@ type dependencies interface {
 	Writer() herodot.Writer
 }
 
-func RejectInsecureRequests(d dependencies, enabled bool, allowTerminationFrom []string) negroni.Handler {
+func EnforceTLSRequests(d dependencies, enabled bool, allowTerminationFrom []string) negroni.Handler {
+	if !enabled {
+		return negroni.HandlerFunc(func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) { next(w, r) })
+	}
+
 	return negroni.HandlerFunc(func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 		if r.TLS != nil ||
-			!enabled ||
 			r.URL.Path == healthx.AliveCheckPath ||
 			r.URL.Path == healthx.ReadyCheckPath ||
 			r.URL.Path == prometheusx.MetricsPrometheusPath {

--- a/tlsx/termination_test.go
+++ b/tlsx/termination_test.go
@@ -1,17 +1,21 @@
+// Copyright © 2025 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
 package tlsx
 
 import (
 	"fmt"
-	"github.com/ory/herodot"
-	"github.com/ory/x/healthx"
-	"github.com/ory/x/logrusx"
-	"github.com/ory/x/prometheusx"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ory/herodot"
+	"github.com/ory/x/healthx"
+	"github.com/ory/x/logrusx"
+	"github.com/ory/x/prometheusx"
 )
 
 func failHandler(t *testing.T) http.HandlerFunc {

--- a/tlsx/termination_test.go
+++ b/tlsx/termination_test.go
@@ -53,19 +53,19 @@ func TestRejectInsecureRequests(t *testing.T) {
 
 	t.Run("no allowTerminationFrom set", func(t *testing.T) {
 		res := httptest.NewRecorder()
-		RejectInsecureRequests(d, true, nil).
+		EnforceTLSRequests(d, true, nil).
 			ServeHTTP(res, &http.Request{RemoteAddr: remoteAddrNotInRange, Header: http.Header{}, URL: new(url.URL)}, failHandler(t))
 		assert.EqualValues(t, http.StatusBadGateway, res.Code)
 
 		res = httptest.NewRecorder()
-		RejectInsecureRequests(d, true, []string{}).
+		EnforceTLSRequests(d, true, []string{}).
 			ServeHTTP(res, &http.Request{RemoteAddr: remoteAddrNotInRange, Header: http.Header{}, URL: new(url.URL)}, failHandler(t))
 		assert.EqualValues(t, http.StatusBadGateway, res.Code)
 	})
 
 	t.Run("tls disabled", func(t *testing.T) {
 		res := httptest.NewRecorder()
-		RejectInsecureRequests(d, false, allowedRanges).
+		EnforceTLSRequests(d, false, allowedRanges).
 			ServeHTTP(res, &http.Request{RemoteAddr: remoteAddrNotInRange, Header: http.Header{}, URL: new(url.URL)}, noopHandler)
 		assert.EqualValues(t, http.StatusNoContent, res.Code)
 	})
@@ -178,7 +178,7 @@ func TestRejectInsecureRequests(t *testing.T) {
 				handler = failHandler(t)
 				expectedStatus = http.StatusBadGateway
 			}
-			RejectInsecureRequests(d, true, allowedRanges).
+			EnforceTLSRequests(d, true, allowedRanges).
 				ServeHTTP(res, tc.req, handler)
 			assert.EqualValues(t, expectedStatus, res.Code)
 		})

--- a/tlsx/termination_test.go
+++ b/tlsx/termination_test.go
@@ -1,0 +1,182 @@
+package tlsx
+
+import (
+	"fmt"
+	"github.com/ory/herodot"
+	"github.com/ory/x/healthx"
+	"github.com/ory/x/logrusx"
+	"github.com/ory/x/prometheusx"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func failHandler(t *testing.T) http.HandlerFunc {
+	return func(http.ResponseWriter, *http.Request) {
+		t.Fatal("handler should not have been called")
+	}
+}
+
+func noopHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
+}
+
+type dependencyProvider struct {
+	l *logrusx.Logger
+	w herodot.Writer
+}
+
+func (d *dependencyProvider) Logger() *logrusx.Logger { return d.l }
+func (d *dependencyProvider) Writer() herodot.Writer  { return d.w }
+
+func TestRejectInsecureRequests(t *testing.T) {
+	d := &dependencyProvider{
+		l: logrusx.New("", ""),
+		w: herodot.NewJSONWriter(logrusx.New("", "")),
+	}
+
+	allowedRanges := []string{"126.0.0.1/24", "127.0.0.1/24"}
+
+	const (
+		addrInRange          = "127.0.0.1"
+		remoteAddrInRange    = "127.0.0.1:123"
+		addrNotInRange       = "227.0.0.1"
+		remoteAddrNotInRange = "227.0.0.1:123s"
+	)
+
+	t.Run("no allowTerminationFrom set", func(t *testing.T) {
+		res := httptest.NewRecorder()
+		RejectInsecureRequests(d, true, nil).
+			ServeHTTP(res, &http.Request{RemoteAddr: remoteAddrNotInRange, Header: http.Header{}, URL: new(url.URL)}, failHandler(t))
+		assert.EqualValues(t, http.StatusBadGateway, res.Code)
+
+		res = httptest.NewRecorder()
+		RejectInsecureRequests(d, true, []string{}).
+			ServeHTTP(res, &http.Request{RemoteAddr: remoteAddrNotInRange, Header: http.Header{}, URL: new(url.URL)}, failHandler(t))
+		assert.EqualValues(t, http.StatusBadGateway, res.Code)
+	})
+
+	t.Run("tls disabled", func(t *testing.T) {
+		res := httptest.NewRecorder()
+		RejectInsecureRequests(d, false, allowedRanges).
+			ServeHTTP(res, &http.Request{RemoteAddr: remoteAddrNotInRange, Header: http.Header{}, URL: new(url.URL)}, noopHandler)
+		assert.EqualValues(t, http.StatusNoContent, res.Code)
+	})
+
+	for _, tc := range []struct {
+		name          string
+		req           *http.Request
+		expectBlocked bool
+	}{{
+		name: "missing x-forwarded-proto",
+		req: &http.Request{
+			RemoteAddr: remoteAddrInRange,
+			Header:     http.Header{},
+			URL:        new(url.URL),
+		},
+		expectBlocked: true,
+	}, {
+		name: "x-forwarded-proto is http",
+		req: &http.Request{
+			RemoteAddr: remoteAddrInRange,
+			Header:     http.Header{"X-Forwarded-Proto": []string{"http"}},
+			URL:        new(url.URL),
+		},
+		expectBlocked: true,
+	}, {
+		name: "missing x-forwarded-for",
+		req: &http.Request{
+			Header: http.Header{"X-Forwarded-Proto": []string{"https"}},
+			URL:    new(url.URL),
+		},
+		expectBlocked: true,
+	}, {
+		name: "remote not in any range",
+		req: &http.Request{
+			RemoteAddr: remoteAddrNotInRange,
+			Header:     http.Header{"X-Forwarded-Proto": []string{"https"}},
+			URL:        new(url.URL),
+		},
+		expectBlocked: true,
+	}, {
+		name: "remote and forwarded not in any range",
+		req: &http.Request{
+			RemoteAddr: remoteAddrNotInRange,
+			Header: http.Header{
+				"X-Forwarded-Proto": []string{"https"},
+				"X-Forwarded-For":   []string{addrNotInRange},
+			},
+			URL: new(url.URL),
+		},
+		expectBlocked: true,
+	}, {
+		name: "remote is in some range",
+		req: &http.Request{
+			RemoteAddr: remoteAddrInRange,
+			Header:     http.Header{"X-Forwarded-Proto": []string{"https"}},
+			URL:        new(url.URL),
+		},
+		expectBlocked: false,
+	}, {
+		name: "one of x-forwarded-for is in some range",
+		req: &http.Request{
+			RemoteAddr: remoteAddrNotInRange,
+			Header: http.Header{
+				"X-Forwarded-For":   []string{fmt.Sprintf("%s, %s, %s", addrNotInRange, addrInRange, addrNotInRange)},
+				"X-Forwarded-Proto": []string{"https"},
+			},
+			URL: new(url.URL),
+		},
+		expectBlocked: false,
+	}, {
+		name: "health alive check is exempted",
+		req: &http.Request{
+			RemoteAddr: remoteAddrNotInRange,
+			Header:     http.Header{},
+			URL:        &url.URL{Path: healthx.AliveCheckPath},
+		},
+		expectBlocked: false,
+	}, {
+		name: "health ready check is exempted",
+		req: &http.Request{
+			RemoteAddr: remoteAddrNotInRange,
+			Header:     http.Header{},
+			URL:        &url.URL{Path: healthx.ReadyCheckPath},
+		},
+		expectBlocked: false,
+	}, {
+		name: "metrics prometheus check is exempted",
+		req: &http.Request{
+			RemoteAddr: remoteAddrNotInRange,
+			Header:     http.Header{},
+			URL:        &url.URL{Path: prometheusx.MetricsPrometheusPath},
+		},
+	}, {
+		name: "x-forwarded-for without spaces",
+		req: &http.Request{
+			RemoteAddr: remoteAddrNotInRange,
+			Header: http.Header{
+				"X-Forwarded-For":   []string{fmt.Sprintf("%s,%s,%s", addrNotInRange, addrInRange, addrNotInRange)},
+				"X-Forwarded-Proto": []string{"https"},
+			},
+			URL: new(url.URL),
+		},
+		expectBlocked: false,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			res := httptest.NewRecorder()
+			handler := noopHandler
+			expectedStatus := http.StatusNoContent
+			if tc.expectBlocked {
+				handler = failHandler(t)
+				expectedStatus = http.StatusBadGateway
+			}
+			RejectInsecureRequests(d, true, allowedRanges).
+				ServeHTTP(res, tc.req, handler)
+			assert.EqualValues(t, expectedStatus, res.Code)
+		})
+	}
+}

--- a/tlsx/termination_test.go
+++ b/tlsx/termination_test.go
@@ -66,6 +66,11 @@ func TestRejectInsecureRequests(t *testing.T) {
 		assert.EqualValues(t, http.StatusBadGateway, res.Code)
 	})
 
+	t.Run("invalid CIDR", func(t *testing.T) {
+		_, err := EnforceTLSRequests(d, []string{"invalidCIDR"})
+		assert.ErrorContains(t, err, "invalid CIDR address")
+	})
+
 	for _, tc := range []struct {
 		name          string
 		req           *http.Request


### PR DESCRIPTION
This PR is moving code from ory/hydra to ory/x:
- https://github.com/ory/hydra/blob/d389fd0269f93c8b7c787f1b3683ae4c6e9e1909/x/tls_termination.go
- https://github.com/ory/hydra/blob/d389fd0269f93c8b7c787f1b3683ae4c6e9e1909/x/tls_termination_test.go