### PR TITLE
WIP: Proposal to support NAT64

### DIFF
--- a/ipx/ip_nat64.go
+++ b/ipx/ip_nat64.go
@@ -1,0 +1,106 @@
+// Copyright © 2023 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package ipx
+
+import (
+	"fmt"
+	"net/netip"
+
+	"code.dny.dev/ssrf"
+)
+
+// PublicIPv4Nat64Prefixes returns the list of public IPv4 to their NAT64 (RFC 6052) IPv6 representation
+func PublicIPv4Nat64Prefixes() []netip.Prefix {
+	return MustConvertToNAT64Prefixes(complementIPv4(ssrf.IPv4DeniedPrefixes))
+}
+
+// MustConvertToNAT64Prefixes convert a list of IPv4 prefixes to a NAT64 (RFC 6052) list of IPv6 prefixes or panic
+func MustConvertToNAT64Prefixes(ps []netip.Prefix) []netip.Prefix {
+	out := make([]netip.Prefix, len(ps))
+	for i, p := range ps {
+		out[i] = MustConvertToNAT64Prefix(p)
+	}
+	return out
+}
+
+// MustConvertToNAT64Prefix convert an IPv4 prefix to a NAT64 (RFC 6052) IPv6 prefix or panic
+func MustConvertToNAT64Prefix(p netip.Prefix) netip.Prefix {
+	if !p.Addr().Is4() {
+		panic(fmt.Errorf("prefix %v is not an IPv4 prefix", p))
+	}
+
+	ipv4Len := p.Bits()
+	if ipv4Len > 32 {
+		panic(fmt.Errorf("invalid IPv4 prefix length: %d", ipv4Len))
+	}
+
+	newLen := 96 + ipv4Len
+	ip4 := p.Addr().As4()
+
+	baseBytes := ssrf.IPv6NAT64Prefix.Addr().As16()
+	copy(baseBytes[12:], ip4[:])
+
+	return netip.PrefixFrom(netip.AddrFrom16(baseBytes), newLen)
+}
+
+// ipToUint32 converts a netip.Addr (IPv4) to its uint32 representation.
+func ipToUint32(a netip.Addr) uint32 {
+	b := a.As4()
+	return uint32(b[0])<<24 | uint32(b[1])<<16 | uint32(b[2])<<8 | uint32(b[3])
+}
+
+// prefixRange returns the first and last IPv4 addresses of p as uint32.
+func prefixRange(p netip.Prefix) (start, end uint32) {
+	// Masked() ensures the address is the network address.
+	base := ipToUint32(p.Masked().Addr())
+	ones, _ := p.Bits(), p.Addr().BitLen()
+	size := uint32(1) << (32 - ones)
+	return base, base + size - 1
+}
+
+// subtractPrefix(r, p) returns the set of IPv4 prefixes covering (r − p)
+// without using AddrRange().
+func subtractPrefix(r, p netip.Prefix) []netip.Prefix {
+	rStart, rEnd := prefixRange(r)
+	pStart, pEnd := prefixRange(p)
+
+	// No overlap
+	if rEnd < pStart || pEnd < rStart {
+		return []netip.Prefix{r}
+	}
+	// p covers r completely
+	if pStart <= rStart && rEnd <= pEnd {
+		return nil
+	}
+	// r strictly contains p: split r into two / (r.Bits()+1) children.
+	childLen := r.Bits() + 1
+	c1 := netip.PrefixFrom(r.Addr(), childLen)
+
+	// Compute base for second child.
+	increment := uint32(1) << (32 - childLen)
+	raw := ipToUint32(r.Addr()) + increment
+	b0 := byte((raw >> 24) & 0xFF)
+	b1 := byte((raw >> 16) & 0xFF)
+	b2 := byte((raw >> 8) & 0xFF)
+	b3 := byte(raw & 0xFF)
+	c2 := netip.PrefixFrom(netip.AddrFrom4([4]byte{b0, b1, b2, b3}), childLen)
+
+	out := subtractPrefix(c1, p)
+	out = append(out, subtractPrefix(c2, p)...)
+	return out
+}
+
+// complementIPv4 returns the minimal set of IPv4 prefixes covering all
+// addresses in 0.0.0.0/0 that are not in any of the input prefixes.
+func complementIPv4(input []netip.Prefix) []netip.Prefix {
+	remainder := []netip.Prefix{netip.MustParsePrefix("0.0.0.0/0")}
+	for _, p := range input {
+		next := make([]netip.Prefix, 0, len(remainder))
+		for _, r := range remainder {
+			next = append(next, subtractPrefix(r, p)...)
+		}
+		remainder = next
+	}
+	return remainder
+}

--- a/ipx/ip_nat64_test.go
+++ b/ipx/ip_nat64_test.go
@@ -1,0 +1,103 @@
+// Copyright © 2023 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package ipx
+
+import (
+	"net/netip"
+	"testing"
+
+	"code.dny.dev/ssrf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMustConvertToNAT64Prefix_ValidInputs(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"192.0.2.0/24", "64:ff9b::c000:200/120"},
+		{"10.0.0.0/8", "64:ff9b::a00:0/104"},
+		{"0.0.0.0/0", "64:ff9b::/96"},
+	}
+
+	for _, tc := range tests {
+		p := netip.MustParsePrefix(tc.in)
+		got := MustConvertToNAT64Prefix(p)
+		assert.Equal(t, tc.want, got.String(), "MustConvertToNAT64Prefix(%q)", tc.in)
+	}
+}
+
+func TestMustConvertToNAT64Prefix_PanicsOnInvalid(t *testing.T) {
+	assert.Panics(t, func() {
+		MustConvertToNAT64Prefix(netip.MustParsePrefix("2001:db8::/32"))
+	}, "Expected panic for non-IPv4 prefix")
+}
+
+func TestMustConvertToNAT64Prefixes_SliceConversion(t *testing.T) {
+	input := []netip.Prefix{
+		netip.MustParsePrefix("192.0.2.0/24"),
+		netip.MustParsePrefix("10.1.0.0/16"),
+	}
+	want := []string{
+		"64:ff9b::c000:200/120",
+		"64:ff9b::a01:0/112",
+	}
+
+	got := MustConvertToNAT64Prefixes(input)
+	require.Len(t, got, len(want), "MustConvertToNAT64Prefixes returned %d entries; want %d", len(got), len(want))
+	for i, p := range got {
+		assert.Equal(t, want[i], p.String(), "Element %d", i)
+	}
+}
+
+func TestPublicIPv4Nat64Prefixes_BasicSanity(t *testing.T) {
+	out := PublicIPv4Nat64Prefixes()
+	require.NotEmpty(t, out, "Expected nonempty slice")
+
+	for _, p := range out {
+		s := p.String()
+		assert.True(t, p.Addr().Is6(), "Returned prefix %q is not IPv6", s)
+		assert.GreaterOrEqual(t, p.Bits(), 96, "Unexpected prefix length for %q", s)
+		assert.LessOrEqual(t, p.Bits(), 128, "Unexpected prefix length for %q", s)
+		base := ssrf.IPv6NAT64Prefix.Addr().String()[:len("64:ff9b:")]
+		assert.True(t, len(s) >= len(base) && s[:len(base)] == base,
+			"Prefix %q does not start with NAT64 base", s,
+		)
+	}
+}
+
+func TestComplementIPv4_FullCoverage(t *testing.T) {
+	denied := ssrf.IPv4DeniedPrefixes
+	allowed := complementIPv4(denied)
+
+	// 1) No denied overlaps any allowed
+	for _, d := range denied {
+		dStart, dEnd := prefixRange(d)
+		for _, a := range allowed {
+			aStart, aEnd := prefixRange(a)
+			overlaps := !(dEnd < aStart || aEnd < dStart)
+			assert.False(t, overlaps, "Denied prefix %q overlaps allowed prefix %q", d, a)
+		}
+	}
+
+	// 2) Denied + allowed cover all /8 blocks exactly once
+	seen := make(map[string]struct{})
+	for _, set := range [][]netip.Prefix{denied, allowed} {
+		for _, p := range set {
+			start, end := prefixRange(p)
+			for ip := start; ip <= end; {
+				octet := byte((ip >> 24) & 0xFF)
+				key, err := netip.AddrFrom4([4]byte{octet, 0, 0, 0}).Prefix(8)
+				require.NoError(t, err)
+				seen[key.String()] = struct{}{}
+				ip += 1 << 24
+				if ip == 0 {
+					break
+				}
+			}
+		}
+	}
+	assert.Len(t, seen, 256, "Denied+allowed did not cover all 256 /8 blocks; covered %d", len(seen))
+}


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch allows by default NAT64 prefixes mirroring the allowed IPv4 prefix in httpx if IPv6 is allowed.
```
-->

This patch enable IPv6 NAT64 for all the ory products. NAT64 start to become common in Kubernetes IPv6 only clusters.

BREAKING CHANGES: This patch allows by default NAT64 prefixes mirroring the allowed IPv4 prefix in httpx if IPv6 is allowed.

## Related Issue or Design Document

No issue created. This is just to talk about the implementation changes with a basic working implementation as reference.

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
