### PR TITLE
fix(pagination): make keyset paginator `ToOptions` idempotent

### DIFF
--- a/pagination/keysetpagination/paginator.go
+++ b/pagination/keysetpagination/paginator.go
@@ -76,15 +76,29 @@ func (p *Paginator) IsLast() bool {
 }
 
 func (p *Paginator) ToOptions() []Option {
-	return []Option{
-		WithToken(p.token),
-		WithSize(p.size),
-		WithDefaultToken(p.defaultToken),
-		WithDefaultSize(p.defaultSize),
-		WithMaxSize(p.maxSize),
-		WithColumn(p.additionalColumn.name, p.additionalColumn.order),
-		withIsLast(p.isLast),
+	opts := make([]Option, 0, 7)
+	if p.token != nil {
+		opts = append(opts, WithToken(p.token))
 	}
+	if p.defaultToken != nil {
+		opts = append(opts, WithDefaultToken(p.defaultToken))
+	}
+	if p.size > 0 {
+		opts = append(opts, WithSize(p.size))
+	}
+	if p.defaultSize != DefaultSize {
+		opts = append(opts, WithDefaultSize(p.defaultSize))
+	}
+	if p.maxSize != DefaultMaxSize {
+		opts = append(opts, WithMaxSize(p.maxSize))
+	}
+	if p.additionalColumn.name != "" {
+		opts = append(opts, WithColumn(p.additionalColumn.name, p.additionalColumn.order))
+	}
+	if p.isLast {
+		opts = append(opts, withIsLast(p.isLast))
+	}
+	return opts
 }
 
 func (p *Paginator) multipleOrderFieldsQuery(q *pop.Query, idField string, cols map[string]*columns.Column, quoteAndContextualize func(string) string) {

--- a/pagination/keysetpagination/paginator_test.go
+++ b/pagination/keysetpagination/paginator_test.go
@@ -269,3 +269,59 @@ func TestPaginateWithAdditionalColumn(t *testing.T) {
 		})
 	}
 }
+
+func TestOptions(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		opts          []Option
+		expectedToken PageToken
+		expectedSize  int
+	}{
+		{
+			name:          "no options",
+			opts:          nil,
+			expectedToken: nil,
+			expectedSize:  DefaultSize,
+		},
+		{
+			name:          "with token",
+			opts:          []Option{WithToken(StringPageToken("token"))},
+			expectedToken: StringPageToken("token"),
+			expectedSize:  DefaultSize,
+		},
+		{
+			name:          "with size",
+			opts:          []Option{WithSize(10)},
+			expectedToken: nil,
+			expectedSize:  10,
+		},
+		{
+			name: "with all options",
+			opts: []Option{
+				WithToken(StringPageToken("token")),
+				WithDefaultToken(StringPageToken("default")),
+				WithSize(20),
+				WithDefaultSize(30),
+				WithMaxSize(50),
+				WithColumn("created_at", "DESC"),
+				withIsLast(true),
+			},
+			expectedToken: StringPageToken("token"),
+			expectedSize:  20,
+		},
+		{
+			name:          "with explicit defaults",
+			opts:          []Option{WithMaxSize(DefaultMaxSize), WithDefaultSize(DefaultSize)},
+			expectedToken: nil,
+			expectedSize:  DefaultSize,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			paginator := GetPaginator(tc.opts...)
+			assert.Equal(t, tc.expectedToken, paginator.Token())
+			assert.Equal(t, tc.expectedSize, paginator.Size())
+
+			assert.Equal(t, paginator, GetPaginator(paginator.ToOptions()...))
+		})
+	}
+}


### PR DESCRIPTION
This change ensures that we can construct a paginator from `ToOptions` which results in the same paginator again. Previously we would apply some defaults incorrectly.