### PR TITLE
fix: fix sorting migration files much more than necessary

### DIFF
--- a/popx/migration_box.go
+++ b/popx/migration_box.go
@@ -251,11 +251,6 @@ func (fm *MigrationBox) findMigrations(
 		}
 
 		fm.Migrations[mf.Direction] = append(fm.Migrations[mf.Direction], mf)
-		mod := sort.Interface(fm.Migrations[mf.Direction])
-		if mf.Direction == "down" {
-			mod = sort.Reverse(mod)
-		}
-		sort.Sort(mod)
 		return nil
 	})
 }


### PR DESCRIPTION
Crux of the issue: for each migration file being found while walking the directory recursively, we added this file to the slice of all migration files **and** immediately sorted this slice. Repeatedly. Since sorting has a complexity of `O(n*log(n))`, the overall complexity is `O(n*n*log(n))`. Thus the running time will worsen badly with each new migration file added.

**But**: `fs.Walkdir` already does the right thing!

> // The files are walked in lexical order, which makes the output deterministic
> // but requires WalkDir to read an entire directory into memory before proceeding
> // to walk that directory.

So we just do not have to sort anything ourselves.

Benefit: a nice speed-up, for example here when running tests in `kratos-oss/selfservice/strategy/code`:

```
 $ hyperfine --shell=none --warmup=2 ./code.test.before  ./code.test.after
Benchmark 1: ./code.test.before
  Time (mean ± σ):     45.584 s ±  0.566 s    [User: 48.562 s, System: 8.605 s]
  Range (min … max):   44.923 s … 47.053 s    10 runs
 
Benchmark 2: ./code.test.after
  Time (mean ± σ):     27.494 s ±  0.380 s    [User: 26.780 s, System: 8.253 s]
  Range (min … max):   26.997 s … 28.365 s    10 runs
 
Summary
  ./code.test.after ran
    1.66 ± 0.03 times faster than ./code.test.before
```


Before the fix, we can indeed see that the run time of `findMigrations` is dominated (95%) by sorting:

<img width="1724" alt="Screenshot 2025-07-01 at 10 52 57" src="https://github.com/user-attachments/assets/5c2d3057-a8e8-4c70-abaf-0fa7731f7054" />


