### PR TITLE
feat: add configurable list of sensitive HTTP headers for redaction

### DIFF
--- a/logrusx/config.schema.json
+++ b/logrusx/config.schema.json
@@ -29,6 +29,14 @@
       "type": "string",
       "title": "Sensitive log value redaction text",
       "description": "Text to use, when redacting sensitive log value."
+    },
+    "custom_sensitive_headers": {
+      "type": "array",
+      "title": "Custom Sensitive Headers",
+      "description": "List of HTTP headers which will be treated as sensitive and redacted.",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "additionalProperties": false

--- a/logrusx/config_test.go
+++ b/logrusx/config_test.go
@@ -38,6 +38,10 @@ func TestConfigSchema(t *testing.T) {
 			"level":                 "trace",
 			"format":                "json_pretty",
 			"leak_sensitive_values": true,
+			"custom_sensitive_headers": []interface{}{
+				"custom_header_1",
+				"custom_header_2",
+			},
 		}
 		assert.NoError(t, schema.ValidateInterface(logConfig))
 
@@ -48,6 +52,8 @@ func TestConfigSchema(t *testing.T) {
 
 		assert.True(t, l.leakSensitive)
 		assert.Equal(t, logrus.TraceLevel, l.Logger.Level)
+		assert.Contains(t, l.customSensitiveHeaders, "custom_header_1")
+		assert.Contains(t, l.customSensitiveHeaders, "custom_header_2")
 		assert.IsType(t, &logrus.JSONFormatter{}, l.Logger.Formatter)
 	})
 

--- a/logrusx/logrus.go
+++ b/logrusx/logrus.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -21,22 +22,24 @@ import (
 
 type (
 	options struct {
-		l             *logrus.Logger
-		level         *logrus.Level
-		formatter     logrus.Formatter
-		format        string
-		reportCaller  bool
-		exitFunc      func(int)
-		leakSensitive bool
-		redactionText string
-		hooks         []logrus.Hook
-		c             configurator
+		l                      *logrus.Logger
+		level                  *logrus.Level
+		formatter              logrus.Formatter
+		format                 string
+		reportCaller           bool
+		exitFunc               func(int)
+		leakSensitive          bool
+		redactionText          string
+		customSensitiveHeaders []string
+		hooks                  []logrus.Hook
+		c                      configurator
 	}
 	Option           func(*options)
 	nullConfigurator struct{}
 	configurator     interface {
 		Bool(key string) bool
 		String(key string) string
+		Strings(path string) []string
 	}
 )
 
@@ -179,12 +182,30 @@ func RedactionText(text string) Option {
 	}
 }
 
+func CustomSensitiveHeaders(headers []string) Option {
+	return func(o *options) {
+		o.customSensitiveHeaders = headers
+	}
+}
+
+func toHeaderMap(headers []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(headers))
+	for _, h := range headers {
+		m[strings.ToLower(h)] = struct{}{}
+	}
+	return m
+}
+
 func (c *nullConfigurator) Bool(_ string) bool {
 	return false
 }
 
 func (c *nullConfigurator) String(_ string) string {
 	return ""
+}
+
+func (c *nullConfigurator) Strings(_ string) []string {
+	return []string{}
 }
 
 func newOptions(opts []Option) *options {
@@ -205,6 +226,12 @@ func New(name string, version string, opts ...Option) *Logger {
 		version:       version,
 		leakSensitive: o.leakSensitive || o.c.Bool("log.leak_sensitive_values"),
 		redactionText: cmp.Or(o.redactionText, `Value is sensitive and has been redacted. To see the value set config key "log.leak_sensitive_values = true" or environment variable "LOG_LEAK_SENSITIVE_VALUES=true".`),
+		customSensitiveHeaders: toHeaderMap(func() []string {
+			if len(o.customSensitiveHeaders) > 0 {
+				return o.customSensitiveHeaders
+			}
+			return o.c.Strings("log.custom_sensitive_headers")
+		}()),
 		Entry: newLogger(o.l, o).WithFields(logrus.Fields{
 			"audience": "application", "service_name": name, "service_version": version}),
 	}

--- a/logrusx/logrus_test.go
+++ b/logrusx/logrus_test.go
@@ -34,6 +34,7 @@ var fakeRequest = &http.Request{
 		"Set-Cookie":      {"kratos_session=2198ef09ac09d09ff098dd123ab128353"},
 		"Cookie":          {"kratos_cookie=2198ef09ac09d09ff098dd123ab128353"},
 		"X-Session-Token": {"2198ef09ac09d09ff098dd123ab128353"},
+		"X-Custom-Header": {"2198ef09ac09d09ff098dd123ab128353"},
 		"Authorization":   {"Bearer 2198ef09ac09d09ff098dd123ab128353"},
 	},
 	Body:       nil,
@@ -195,12 +196,33 @@ func TestTextLogger(t *testing.T) {
 				`cookie:Value is sensitive and has been redacted. To see the value set config key "log.leak_sensitive_values = true" or environment variable "LOG_LEAK_SENSITIVE_VALUES=true".`,
 				`x-session-token:Value is sensitive and has been redacted. To see the value set config key "log.leak_sensitive_values = true" or environment variable "LOG_LEAK_SENSITIVE_VALUES=true".`,
 				`authorization:Value is sensitive and has been redacted. To see the value set config key "log.leak_sensitive_values = true" or environment variable "LOG_LEAK_SENSITIVE_VALUES=true".`,
+				"x-custom-header:2198ef09ac09d09ff098dd123ab128353",
 			},
 			notExpect: []string{
 				"set-cookie:kratos_session=2198ef09ac09d09ff098dd123ab128353",
 				"cookie:kratos_cookie=2198ef09ac09d09ff098dd123ab128353",
 				"x-session-token:2198ef09ac09d09ff098dd123ab128353",
 				"authorization:Bearer 2198ef09ac09d09ff098dd123ab128353",
+			},
+			call: func(l *Logger) {
+				l.WithRequest(fakeRequest).Debug()
+			},
+		},
+		{
+			l: New("logrusx-server", "v0.0.1", ForceFormat("text"), CustomSensitiveHeaders([]string{"x-custom-header"}), ForceLevel(logrus.DebugLevel)),
+			expect: []string{
+				"set-cookie:Value is sensitive and has been redacted. To see the value set config key \"log.leak_sensitive_values = true\" or environment variable \"LOG_LEAK_SENSITIVE_VALUES=true\".",
+				`cookie:Value is sensitive and has been redacted. To see the value set config key "log.leak_sensitive_values = true" or environment variable "LOG_LEAK_SENSITIVE_VALUES=true".`,
+				`x-session-token:Value is sensitive and has been redacted. To see the value set config key "log.leak_sensitive_values = true" or environment variable "LOG_LEAK_SENSITIVE_VALUES=true".`,
+				`authorization:Value is sensitive and has been redacted. To see the value set config key "log.leak_sensitive_values = true" or environment variable "LOG_LEAK_SENSITIVE_VALUES=true".`,
+				`x-custom-header:Value is sensitive and has been redacted. To see the value set config key "log.leak_sensitive_values = true" or environment variable "LOG_LEAK_SENSITIVE_VALUES=true".`,
+			},
+			notExpect: []string{
+				"set-cookie:kratos_session=2198ef09ac09d09ff098dd123ab128353",
+				"cookie:kratos_cookie=2198ef09ac09d09ff098dd123ab128353",
+				"x-session-token:2198ef09ac09d09ff098dd123ab128353",
+				"authorization:Bearer 2198ef09ac09d09ff098dd123ab128353",
+				"x-custom-header:2198ef09ac09d09ff098dd123ab128353",
 			},
 			call: func(l *Logger) {
 				l.WithRequest(fakeRequest).Debug()


### PR DESCRIPTION
By default, Oathkeeper redacts sensitive values from the logs like the Authorization HTTP header and cookie values. However, when defining a custom header with a token, the value of this token is not redacted. These changes add an option: custom_sensitive_headers. Headers listed in this option will be treated as sensitive and redacted as well.

BREAKING CHANGES: NO


## Related Issue or Design Document

[#1081](https://github.com/ory/oathkeeper/issues/1081) [#3687](https://github.com/ory/hydra/issues/3687)


## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

New Configuration Example:

```json
{
	"level": "trace",
	"format": "json_pretty",
	"leak_sensitive_values": true,
	"custom_sensitive_headers": [
		"X-My-Sensitive-Header-1",
		"X-My-Sensitive-Header-2",
	],
}
```
